### PR TITLE
fix can't find app_main issue

### DIFF
--- a/examples/espidf-hello-world/src/main.c
+++ b/examples/espidf-hello-world/src/main.c
@@ -24,7 +24,7 @@ void hello_task(void *pvParameter)
     system_restart();
 }
 
-void app_main()
+extern "C" void app_main()
 {
     nvs_flash_init();
     system_init();

--- a/examples/espidf-http-request/src/main.c
+++ b/examples/espidf-http-request/src/main.c
@@ -172,7 +172,7 @@ static void http_get_task(void *pvParameters)
     }
 }
 
-void app_main()
+extern "C" void app_main()
 {
     nvs_flash_init();
     system_init();


### PR DESCRIPTION
can't compile successfully in macOS without `extern "C" `