### PR TITLE
Add ESPectro32 board definition

### DIFF
--- a/boards/espectro32.json
+++ b/boards/espectro32.json
@@ -1,0 +1,34 @@
+{
+  "build": {
+    "core": "esp32",
+    "extra_flags": "-DESP32_DEV -DARDUINO_ESPECTRO32",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "ldscript": "esp32_out.ld",
+    "mcu": "esp32",
+    "variant": "espectro32"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "frameworks":  [
+    "arduino",
+    "espidf"
+  ],
+  "name": "ESPectro32",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 294912,
+    "maximum_size": 1310720,
+    "require_upload_port": true,
+    "resetmethod": "nodemcu",
+    "speed": 2000000,
+    "wait_for_upload_port": true
+  },
+  "url": "https://shop.makestro.com/product/espectro32",
+  "vendor": "DycodeX"
+}


### PR DESCRIPTION
ESPectro32 product detail: https://shop.makestro.com/product/espectro32/

I also have added this board to espressif/arduino-esp32. PR: https://github.com/espressif/arduino-esp32/pull/586