### PR TITLE
The '-' (dash) has been changed to '_' (underscore) in the macro names.

### DIFF
--- a/boards/esp32-evb.json
+++ b/boards/esp32-evb.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "esp32",
-    "extra_flags": "-DARDUINO_ESP32-EVB",
+    "extra_flags": "-DARDUINO_ESP32_EVB",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",

--- a/boards/esp32-gateway.json
+++ b/boards/esp32-gateway.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "esp32",
-    "extra_flags": "-DARDUINO_ESP32-GATEWAY",
+    "extra_flags": "-DARDUINO_ESP32_GATEWAY",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",

--- a/boards/esp32vn-iot-uno.json
+++ b/boards/esp32vn-iot-uno.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "esp32",
-    "extra_flags": "-DARDUINO_esp32vn-iot-uno",
+    "extra_flags": "-DARDUINO_esp32vn_iot_uno",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",

--- a/boards/m5stack-core-esp32.json
+++ b/boards/m5stack-core-esp32.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "esp32",
-    "extra_flags": "-DARDUINO_M5Stack-Core-ESP32",
+    "extra_flags": "-DARDUINO_M5Stack_Core_ESP32",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",

--- a/boards/nodemcu-32s.json
+++ b/boards/nodemcu-32s.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "esp32",
-    "extra_flags": "-DARDUINO_NodeMCU-32S",
+    "extra_flags": "-DARDUINO_NodeMCU_32S",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",


### PR DESCRIPTION
This is a pull request for bug #81 