### PR TITLE
add psram build flag for wrover kit

### DIFF
--- a/boards/esp-wrover-kit.json
+++ b/boards/esp-wrover-kit.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "esp32",
-    "extra_flags": "-DARDUINO_ESP32_DEV",
+    "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",


### PR DESCRIPTION
Add the build flag required for Arduino framework to enable the external memory.

Tested with:
```
platform = https://github.com/sarfata/platform-espressif32.git#feature/add-psram-build-flag-for-wrover-kit
framework = arduino
```

Output:
```
Running - Free heap=4393060
```
