### PR TITLE
Bugfix platform.py

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -57,7 +57,7 @@ class Espressif32Platform(PlatformBase):
             if link in ("esp-prog", "ftdi"):
                 openocd_interface = "esp32_devkitj_v1"
             elif link == "minimodule":
-                openocd_interface = "mbftdi"
+                openocd_interface = "minimodule"
             else:
                 openocd_interface = link
 


### PR DESCRIPTION
debug_tool = minimodule selects wrong config file mbftdi.cfg, should be minimodule.cfg