### PR TITLE
Remove "Automatically generated file; DO NOT EDIT." from "sdkconfig.h"

### DIFF
--- a/examples/espidf-arduino-blink/src/sdkconfig.h
+++ b/examples/espidf-arduino-blink/src/sdkconfig.h
@@ -1,6 +1,5 @@
 /*
  *
- * Automatically generated file; DO NOT EDIT.
  * Espressif IoT Development Framework Configuration
  *
  */

--- a/examples/espidf-arduino-wifiscan/src/sdkconfig.h
+++ b/examples/espidf-arduino-wifiscan/src/sdkconfig.h
@@ -1,6 +1,5 @@
 /*
  *
- * Automatically generated file; DO NOT EDIT.
  * Espressif IoT Development Framework Configuration
  *
  */

--- a/examples/espidf-aws-iot/src/sdkconfig.h
+++ b/examples/espidf-aws-iot/src/sdkconfig.h
@@ -1,6 +1,5 @@
 /*
  *
- * Automatically generated file; DO NOT EDIT.
  * Espressif IoT Development Framework Configuration
  *
  */

--- a/examples/espidf-ble-adv/src/sdkconfig.h
+++ b/examples/espidf-ble-adv/src/sdkconfig.h
@@ -1,6 +1,5 @@
 /*
  *
- * Automatically generated file; DO NOT EDIT.
  * Espressif IoT Development Framework Configuration
  *
  */

--- a/examples/espidf-blink/src/sdkconfig.h
+++ b/examples/espidf-blink/src/sdkconfig.h
@@ -1,6 +1,5 @@
 /*
  *
- * Automatically generated file; DO NOT EDIT.
  * Espressif IoT Development Framework Configuration
  *
  */

--- a/examples/espidf-coap-server/src/sdkconfig.h
+++ b/examples/espidf-coap-server/src/sdkconfig.h
@@ -1,6 +1,5 @@
 /*
  *
- * Automatically generated file; DO NOT EDIT.
  * Espressif IoT Development Framework Configuration
  *
  */

--- a/examples/espidf-exceptions/src/sdkconfig.h
+++ b/examples/espidf-exceptions/src/sdkconfig.h
@@ -1,6 +1,5 @@
 /*
  *
- * Automatically generated file; DO NOT EDIT.
  * Espressif IoT Development Framework Configuration
  *
  */

--- a/examples/espidf-hello-world/src/sdkconfig.h
+++ b/examples/espidf-hello-world/src/sdkconfig.h
@@ -1,6 +1,5 @@
 /*
  *
- * Automatically generated file; DO NOT EDIT.
  * Espressif IoT Development Framework Configuration
  *
  */

--- a/examples/espidf-http-request/src/sdkconfig.h
+++ b/examples/espidf-http-request/src/sdkconfig.h
@@ -1,6 +1,5 @@
 /*
  *
- * Automatically generated file; DO NOT EDIT.
  * Espressif IoT Development Framework Configuration
  *
  */

--- a/examples/espidf-peripherals-uart/src/sdkconfig.h
+++ b/examples/espidf-peripherals-uart/src/sdkconfig.h
@@ -1,6 +1,5 @@
 /*
  *
- * Automatically generated file; DO NOT EDIT.
  * Espressif IoT Development Framework Configuration
  *
  */

--- a/examples/espidf-storage-sdcard/src/sdkconfig.h
+++ b/examples/espidf-storage-sdcard/src/sdkconfig.h
@@ -1,6 +1,5 @@
 /*
  *
- * Automatically generated file; DO NOT EDIT.
  * Espressif IoT Development Framework Configuration
  *
  */

--- a/examples/espidf-ulp-adc/src/sdkconfig.h
+++ b/examples/espidf-ulp-adc/src/sdkconfig.h
@@ -1,6 +1,5 @@
 /*
  *
- * Automatically generated file; DO NOT EDIT.
  * Espressif IoT Development Framework Configuration
  *
  */

--- a/examples/espidf-ulp-pulse/src/sdkconfig.h
+++ b/examples/espidf-ulp-pulse/src/sdkconfig.h
@@ -1,6 +1,5 @@
 /*
  *
- * Automatically generated file; DO NOT EDIT.
  * Espressif IoT Development Framework Configuration
  *
  */


### PR DESCRIPTION
Just noticed that this commit/change was lost in the a4c3a868ba18e2d1767ee40179d4d2aa03a4773b update to examples. 

Essentially re-applying 4646af1de26fa0eb8d5f2cf29856cb1b1c00f32a as well as updating subsequently added examples
`find ./examples/ -type f -name "sdkconfig.h" -exec sed -i -e "/* Automatically generated file; DO NOT EDIT./d" {} \;`