### PR TITLE
Change default serial upload speed to 460k

### DIFF
--- a/boards/alksesp32.json
+++ b/boards/alksesp32.json
@@ -27,7 +27,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://github.com/RoboticsBrno/ArduinoLearningKitStarter.git",
   "vendor": "RoboticsBrno"

--- a/boards/bpi-bit.json
+++ b/boards/bpi-bit.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://en.wikipedia.org/wiki/ESP32",
   "vendor": "BPI Tech"

--- a/boards/d-duino-32.json
+++ b/boards/d-duino-32.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://www.tindie.com/products/lspoplove/dstike-d-duino-32-v3/",
   "vendor": "DSTIKE"

--- a/boards/esp-wrover-kit.json
+++ b/boards/esp-wrover-kit.json
@@ -43,7 +43,7 @@
       "ftdi"
     ],
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://espressif.com/en/products/hardware/esp-wrover-kit/overview",
   "vendor": "Espressif"

--- a/boards/esp32-evb.json
+++ b/boards/esp32-evb.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://www.olimex.com/Products/IoT/ESP32-EVB/open-source-hardware",
   "vendor": "OLIMEX"

--- a/boards/esp32-gateway.json
+++ b/boards/esp32-gateway.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://www.olimex.com/Products/IoT/ESP32-GATEWAY/open-source-hardware",
   "vendor": "OLIMEX"

--- a/boards/esp32-poe.json
+++ b/boards/esp32-poe.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://www.olimex.com/Products/IoT/ESP32/ESP32-POE/open-source-hardware",
   "vendor": "OLIMEX"

--- a/boards/esp32-pro.json
+++ b/boards/esp32-pro.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://www.olimex.com/Products/IoT/ESP32/ESP32-PRO/open-source-hardware",
   "vendor": "OLIMEX"

--- a/boards/esp320.json
+++ b/boards/esp320.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://www.sweetpeas.se/controller-modules/10-esp210.html",
   "vendor": "Electronic SweetPeas"

--- a/boards/esp32dev.json
+++ b/boards/esp32dev.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://en.wikipedia.org/wiki/ESP32",
   "vendor": "Espressif"

--- a/boards/esp32doit-devkit-v1.json
+++ b/boards/esp32doit-devkit-v1.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://www.doit.am/",
   "vendor": "DOIT"

--- a/boards/esp32thing.json
+++ b/boards/esp32thing.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://www.sparkfun.com/products/13907",
   "vendor": "SparkFun Electronics"

--- a/boards/esp32vn-iot-uno.json
+++ b/boards/esp32vn-iot-uno.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://esp32.vn/",
   "vendor": "ESP32vn"

--- a/boards/espea32.json
+++ b/boards/espea32.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://blog.aprbrother.com/product/espea",
   "vendor": "April Brother"

--- a/boards/espectro32.json
+++ b/boards/espectro32.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 2000000
+    "speed": 460800
   },
   "url": "https://shop.makestro.com/product/espectro32",
   "vendor": "DycodeX"

--- a/boards/espino32.json
+++ b/boards/espino32.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://thaieasyelec.com/products/development-boards/espino-wifi-development-board-detail.html",
   "vendor": "ThaiEasyElec"

--- a/boards/featheresp32.json
+++ b/boards/featheresp32.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://www.adafruit.com/product/3405",
   "vendor": "Adafruit"

--- a/boards/firebeetle32.json
+++ b/boards/firebeetle32.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://dfrobotblog.wordpress.com",
   "vendor": "DFRobot"

--- a/boards/fm-devkit.json
+++ b/boards/fm-devkit.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://github.com/dragon-engineer/esp32_fmdevkit",
   "vendor": "Unknown"

--- a/boards/frogboard.json
+++ b/boards/frogboard.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://www.tindie.com/products/fred_IOT/esp32s-esp-wroom32-frogopins-development-board/",
   "vendor": "Fred"

--- a/boards/heltec_wifi_kit_32.json
+++ b/boards/heltec_wifi_kit_32.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://www.heltec.cn/project/wifi-kit-32/?lang=en",
   "vendor": "Heltec Automation"

--- a/boards/heltec_wifi_lora_32.json
+++ b/boards/heltec_wifi_lora_32.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://www.heltec.cn",
   "vendor": "Heltec Automation"

--- a/boards/heltec_wifi_lora_32_V2.json
+++ b/boards/heltec_wifi_lora_32_V2.json
@@ -29,7 +29,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 8388608,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://www.heltec.cn/project/wifi-lora-32/?lang=en",
   "vendor": "Heltec Automation"

--- a/boards/heltec_wireless_stick.json
+++ b/boards/heltec_wireless_stick.json
@@ -29,7 +29,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 8388608,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://www.heltec.cn/project/wireless-stick/?lang=en",
   "vendor": "Heltec Automation"

--- a/boards/hornbill32dev.json
+++ b/boards/hornbill32dev.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://hackaday.io/project/18997-hornbill",
   "vendor": "Hornbill"

--- a/boards/hornbill32minima.json
+++ b/boards/hornbill32minima.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://hackaday.io/project/18997-hornbill",
   "vendor": "Hornbill"

--- a/boards/intorobot.json
+++ b/boards/intorobot.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://docs.intorobot.com/zh/hardware/fig/hardware/",
   "vendor": "IntoRobot"

--- a/boards/iotbusio.json
+++ b/boards/iotbusio.json
@@ -30,7 +30,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://www.oddwires.com/iot-bus-io-esp32-processor-with-wifi-and-bluetooth/",
   "vendor": "oddWires"

--- a/boards/iotbusproteus.json
+++ b/boards/iotbusproteus.json
@@ -30,7 +30,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://www.oddwires.com/proteus-iot-bus-esp32-microprocessor-wi-fi-and-bluetooth-with-prototype-board-form-factor/",
   "vendor": "oddWires"

--- a/boards/lolin32.json
+++ b/boards/lolin32.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://wiki.wemos.cc/products:lolin32:lolin32",
   "vendor": "WEMOS"

--- a/boards/lolin_d32.json
+++ b/boards/lolin_d32.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://wiki.wemos.cc/products:d32:d32",
   "vendor": "WEMOS"

--- a/boards/lolin_d32_pro.json
+++ b/boards/lolin_d32_pro.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://wiki.wemos.cc/products:d32:d32_pro",
   "vendor": "WEMOS"

--- a/boards/lopy.json
+++ b/boards/lopy.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://pycom.io/",
   "vendor": "Pycom Ltd."

--- a/boards/lopy4.json
+++ b/boards/lopy4.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 1310720,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://pycom.io/",
   "vendor": "Pycom Ltd."

--- a/boards/m5stack-core-esp32.json
+++ b/boards/m5stack-core-esp32.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://www.m5stack.com",
   "vendor": "M5Stack"

--- a/boards/m5stack-fire.json
+++ b/boards/m5stack-fire.json
@@ -26,7 +26,7 @@
     "maximum_ram_size": 6553600,
     "maximum_size": 16777216,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://www.m5stack.com",
   "vendor": "M5Stack"

--- a/boards/m5stack-grey.json
+++ b/boards/m5stack-grey.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 532480,
     "maximum_size": 16777216,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://www.m5stack.com",
   "vendor": "M5Stack"

--- a/boards/m5stick-c.json
+++ b/boards/m5stick-c.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 1500000
+    "speed": 460800
   },
   "url": "http://www.m5stack.com",
   "vendor": "M5Stack"

--- a/boards/mhetesp32devkit.json
+++ b/boards/mhetesp32devkit.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://forum.mhetlive.com",
   "vendor": "MH-ET Live"

--- a/boards/mhetesp32minikit.json
+++ b/boards/mhetesp32minikit.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://forum.mhetlive.com",
   "vendor": "MH-ET Live"

--- a/boards/microduino-core-esp32.json
+++ b/boards/microduino-core-esp32.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 2000000
+    "speed": 460800
   },
   "url": "https://microduinoinc.com",
   "vendor": "Microduino"

--- a/boards/nano32.json
+++ b/boards/nano32.json
@@ -27,7 +27,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://iot-bits.com/nano32-esp32-development-board",
   "vendor": "MakerAsia"

--- a/boards/nina_w10.json
+++ b/boards/nina_w10.json
@@ -26,7 +26,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 2097152,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://www.u-blox.com/en/product/nina-w10-series",
   "vendor": "u-blox"

--- a/boards/node32s.json
+++ b/boards/node32s.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://www.ayarafun.com",
   "vendor": "Aiyarafun"

--- a/boards/nodemcu-32s.json
+++ b/boards/nodemcu-32s.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://www.nodemcu.com/",
   "vendor": "NodeMCU"

--- a/boards/odroid_esp32.json
+++ b/boards/odroid_esp32.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 16777216,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://www.hardkernel.com/main/products/prdt_info.php?g_code=G152875062626",
   "vendor": "Hardkernel"

--- a/boards/onehorse32dev.json
+++ b/boards/onehorse32dev.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://www.tindie.com/products/onehorse/esp32-development-board/",
   "vendor": "Onehorse"

--- a/boards/oroca_edubot.json
+++ b/boards/oroca_edubot.json
@@ -26,7 +26,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://github.com/oroca/OROCA-EduBot",
   "vendor": "OROCA"

--- a/boards/pico32.json
+++ b/boards/pico32.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://esp-idf.readthedocs.io/en/latest/get-started/get-started-pico-kit.html",
   "vendor": "Espressif"

--- a/boards/pocket_32.json
+++ b/boards/pocket_32.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://dong-sen.com",
   "vendor": "Dongsen Technology"

--- a/boards/quantum.json
+++ b/boards/quantum.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 16777216,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://wiki.jackslab.org/Noduino",
   "vendor": "Noduino"

--- a/boards/sparkfun_lora_gateway_1-channel.json
+++ b/boards/sparkfun_lora_gateway_1-channel.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://www.sparkfun.com/products/15006",
   "vendor": "SparkFun"

--- a/boards/ttgo-lora32-v1.json
+++ b/boards/ttgo-lora32-v1.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://www.google.com.ua/search?q=TTGO+LoRa32-OLED+V1",
   "vendor": "TTGO"

--- a/boards/ttgo-t-beam.json
+++ b/boards/ttgo-t-beam.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 1310720,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://github.com/LilyGO/TTGO-T-Beam",
   "vendor": "TTGO"

--- a/boards/turta_iot_node.json
+++ b/boards/turta_iot_node.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://www.turta.io/en/iotnode",
   "vendor": "Turta"

--- a/boards/wemosbat.json
+++ b/boards/wemosbat.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://www.wemos.cc",
   "vendor": "WEMOS"

--- a/boards/wesp32.json
+++ b/boards/wesp32.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://wesp32.com/",
   "vendor": "Silicognition"

--- a/boards/widora-air.json
+++ b/boards/widora-air.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 16777216,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "http://widora.io",
   "vendor": "Widora"

--- a/boards/xinabox_cw02.json
+++ b/boards/xinabox_cw02.json
@@ -28,7 +28,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 460800
   },
   "url": "https://xinabox.cc/products/cw02",
   "vendor": "XinaBox"


### PR DESCRIPTION
Whilst the esp8266/Arduino core has defaulted and limited their
upload speeds to 460800, the ESP32 core has not, but is subject
to the same issues, namely compatability issues with CH340 usb
serial chip and higher baud rates (possibly only on *nix based
systems).

There is possibly little benefit going higher than 460800 due
to flash erase and write times rather than serial transfer
times (even if it were to connect reliably).

sed -i "s/\"speed\".*/\"speed\": 460800/g" boards/*.json