### PR TITLE
Fix espidf delineation of kconfig args

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -452,9 +452,9 @@ def generate_project_ld_script(target, source, env):
             ["\"%s\"" % f for f in project_files.get("lf_files")]),
         "output": target[0].get_path(),
         "kconfig": join(FRAMEWORK_DIR, "Kconfig"),
-        "kconfigs_projbuild": "COMPONENT_KCONFIGS_PROJBUILD=%s" % "#".join(
+        "kconfigs_projbuild": "COMPONENT_KCONFIGS_PROJBUILD=%s" % " ".join(
             ["%s" % f for f in project_files.get("kconfig_build_files")]),
-        "kconfig_files": "COMPONENT_KCONFIGS=%s" % "#".join(
+        "kconfig_files": "COMPONENT_KCONFIGS=%s" % " ".join(
             ["%s" % f for f in project_files.get("kconfig_files")]),
     }
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -452,9 +452,9 @@ def generate_project_ld_script(target, source, env):
             ["\"%s\"" % f for f in project_files.get("lf_files")]),
         "output": target[0].get_path(),
         "kconfig": join(FRAMEWORK_DIR, "Kconfig"),
-        "kconfigs_projbuild": "COMPONENT_KCONFIGS_PROJBUILD=%s" % " ".join(
+        "kconfigs_projbuild": "COMPONENT_KCONFIGS_PROJBUILD=%s" % "\t".join(
             ["%s" % f for f in project_files.get("kconfig_build_files")]),
-        "kconfig_files": "COMPONENT_KCONFIGS=%s" % " ".join(
+        "kconfig_files": "COMPONENT_KCONFIGS=%s" % "\t".join(
             ["%s" % f for f in project_files.get("kconfig_files")]),
     }
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -452,16 +452,16 @@ def generate_project_ld_script(target, source, env):
             ["\"%s\"" % f for f in project_files.get("lf_files")]),
         "output": target[0].get_path(),
         "kconfig": join(FRAMEWORK_DIR, "Kconfig"),
-        "kconfigs_projbuild": "COMPONENT_KCONFIGS_PROJBUILD=%s" % "\t".join(
+        "kconfigs_projbuild": "COMPONENT_KCONFIGS_PROJBUILD=%s" % "#".join(
             ["%s" % f for f in project_files.get("kconfig_build_files")]),
-        "kconfig_files": "COMPONENT_KCONFIGS=%s" % "\t".join(
+        "kconfig_files": "COMPONENT_KCONFIGS=%s" % "#".join(
             ["%s" % f for f in project_files.get("kconfig_files")]),
     }
 
     cmd = ('"$PYTHONEXE" "{script}" --sections "{sections}" --input "{input}" '
         '--config "{sdk_header}" --fragments {fragments} --output "{output}" '
         '--kconfig "{kconfig}" --env "{kconfigs_projbuild}" '
-        '--env "{kconfig_files}" --env "IDF_CMAKE=n" '
+        '--env "{kconfig_files}" --env "IDF_CMAKE=n" --env "IFS=#" '
         '--env "IDF_TARGET=\\\"esp32\\\""').format(**args)
 
     env.Execute(cmd)


### PR DESCRIPTION
Use space instead of # to delineate kconfig args.

partial fix for https://github.com/platformio/platform-espressif32/issues/226

@valeros test output https://github.com/atanisoft/ESP32CommandStation/runs/224036767