### PR TITLE
[m5stick-c] Correct upload speed

### DIFF
--- a/boards/m5stick-c.json
+++ b/boards/m5stick-c.json
@@ -25,7 +25,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 460800
+    "speed": 1500000
   },
   "url": "http://www.m5stack.com",
   "vendor": "M5Stack"


### PR DESCRIPTION
The current upload speed gives an error when trying to upload on m5stick-c:
```
Configuring flash size...

A fatal error occurred: Timed out waiting for packet header
*** [upload] Error 2
```
With `1500000 `the upload works correctly.

Other reference; arduino IDE [m5stick-c definition](https://github.com/espressif/arduino-esp32/blob/c8d8dc226545a096a34bf5164551c087b658d33a/boards.txt#L2446)
