### PR TITLE
Created board for LilyGo TTGO LoRa32-OLED V2

### DIFF
--- a/boards/ttgo-lora32-v2.json
+++ b/boards/ttgo-lora32-v2.json
@@ -1,0 +1,35 @@
+{
+  "build": {
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_TTGO_LoRa32_V2",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "ldscript": "esp32_out.ld",
+    "mcu": "esp32",
+    "variant": "ttgo-lora32-v2"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "TTGO LoRa32-OLED V2",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://github.com/LilyGO/TTGO-LORA32-V2.0",
+  "vendor": "TTGO"
+}


### PR DESCRIPTION
Hi,

I have added a board for the [LilyGo TTGO LoRa32-OLED V2](https://github.com/LilyGO/TTGO-LORA32-V2.0), which is similar to the LilyGo TTGO LoRa32-OLED V1 but with a different pinout. l have already created a pull request on [arduino-esp32](https://github.com/espressif/arduino-esp32/pull/3479) for the platform-espressif32.

Cheers.