### PR TITLE
Added support for Qchip board

### DIFF
--- a/boards/qchip.json
+++ b/boards/qchip.json
@@ -1,0 +1,32 @@
+{
+    "build": {
+      "core": "esp32",
+      "extra_flags": "-DARDUINO_HELTEC_WIFI_KIT_32",
+      "f_cpu": "240000000L",
+      "f_flash": "40000000L",
+      "flash_mode": "dio",
+      "ldscript": "esp32_out.ld",
+      "mcu": "esp32",
+      "variant": "heltec_wifi_kit_32"
+    },
+    "connectivity": [
+      "wifi",
+      "bluetooth",
+      "ethernet",
+      "can"
+    ],
+    "frameworks": [
+      "arduino",
+      "espidf"
+    ],
+    "name": "Qchip",
+    "upload": {
+      "flash_size": "4MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 4194304,
+      "require_upload_port": true,
+      "speed": 460800
+    },
+    "url": "http://qmobot.com/",
+    "vendor": "Qmobot LLP"
+  }


### PR DESCRIPTION
Hello!
Please, pull my request.
Created support for Qchip (Heltec based IoT board). 
Qchip used in [Qmobot robots](https://qmobot.com).

Thank you for your great project!