### PR TITLE
Add esp_exception_decoder filter for device monitor

### DIFF
--- a/monitor/filter_exception_decoder.py
+++ b/monitor/filter_exception_decoder.py
@@ -97,6 +97,7 @@ class Esp32ExceptionDecoder(DeviceMonitorFilter):
         try:
             for i, addr in enumerate(match.group(1).split()):
                 output = subprocess.check_output(args + [ addr.encode(enc) ]).decode(enc).strip()
+                output = output.replace("\n", "\n     ") # newlines happen with inlined methods
                 output = self.strip_project_dir(output)
                 trace += "  #%-2d %s in %s\n" % (i, addr, output)
         except subprocess.CalledProcessError as e:

--- a/monitor/filter_exception_decoder.py
+++ b/monitor/filter_exception_decoder.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+import subprocess
+import sys
+
+from serial.tools import miniterm
+
+from platformio.project.config import ProjectConfig
+from platformio.project.exception import PlatformioException
+from platformio.project.helpers import load_project_ide_data
+from platformio.commands.device import DeviceMonitorFilter
+
+
+class EspExceptionDecoder(DeviceMonitorFilter):
+    NAME = "esp_exception_decoder"
+
+    def __call__(self):
+        self.buffer = ""
+        self.backtrace_re = re.compile(r"^Backtrace: ((0x[0-9a-f]+:0x[0-9a-f]+ ?)+)\s*$")
+
+        self.firmware_path = None
+        self.addr2line_path = None
+        self.enabled = self.setup_paths()
+        return self
+
+    def setup_paths(self):
+        self.project_dir = os.path.abspath(self.project_dir)
+        if not self.project_dir.endswith(os.path.sep):
+            self.project_dir += os.path.sep
+
+        try:
+            data = load_project_ide_data(self.project_dir, self.environment)
+            self.firmware_path = data["prog_path"]
+            if not os.path.isfile(self.firmware_path):
+                sys.stderr.write("%s: firmware at %s does not exist, rebuild the project?\n" %
+                    (self.__class__.__name__, self.firmware_path))
+                return False
+
+            cc_path = data.get("cc_path", "")
+            if "-gcc" in cc_path:
+                path = cc_path.replace("-gcc", "-addr2line")
+                if os.path.isfile(path):
+                    self.addr2line_path = path
+                    return True
+        except PlatformioException as e:
+            sys.stderr.write("%s: disabling, exception while looking for addr2line: %s\n" %
+                (self.__class__.__name__, e))
+            return False
+        sys.stderr.write("%s: disabling, failed to find addr2line.\n" % self.__class__.__name__)
+        return False
+
+    def rx(self, text):
+        if not self.enabled:
+            return text
+
+        last = 0
+        while True:
+            idx = text.find("\n", last)
+            if idx == -1:
+                if len(self.buffer) < 4096:
+                    self.buffer += text[last:]
+                break
+
+            line = text[last:idx]
+            if self.buffer:
+                line = self.buffer + line
+                self.buffer = ""
+            last = idx+1
+
+            m = self.backtrace_re.match(line)
+            if m is None:
+                continue
+
+            trace = self.get_backtrace(m)
+            if len(trace) != "":
+                text = text[:idx+1] + trace + text[idx+1:]
+                last += len(trace)
+        return text
+
+    def get_backtrace(self, match):
+        trace = ""
+        try:
+            args = [ self.addr2line_path, "-fipC", "-e", self.firmware_path ]
+            for i, addr in enumerate(match.group(1).split()):
+                output = subprocess.check_output(args + [ addr ]) \
+                    .decode("utf-8").strip().replace(self.project_dir, "")
+                trace += "  #%-2d %s in %s\n" % (i, addr, output)
+        except subprocess.CalledProcessError as e:
+            sys.stderr.write("%s: failed to call %s: %s\n" %
+                (self.__class__.__name__, self.addr2line_path, e))
+        return trace

--- a/monitor/filter_exception_decoder.py
+++ b/monitor/filter_exception_decoder.py
@@ -26,8 +26,8 @@ from platformio.project.helpers import load_project_ide_data
 from platformio.commands.device import DeviceMonitorFilter
 
 
-class EspExceptionDecoder(DeviceMonitorFilter):
-    NAME = "esp_exception_decoder"
+class Esp32ExceptionDecoder(DeviceMonitorFilter):
+    NAME = "esp32_exception_decoder"
 
     def __call__(self):
         self.buffer = ""

--- a/monitor/filter_exception_decoder.py
+++ b/monitor/filter_exception_decoder.py
@@ -17,14 +17,13 @@ import re
 import subprocess
 import sys
 
-from serial.tools import miniterm
-
 from platformio.compat import get_filesystem_encoding, path_to_unicode
-from platformio.project.config import ProjectConfig
 from platformio.project.exception import PlatformioException
 from platformio.project.helpers import load_project_ide_data
 from platformio.commands.device import DeviceMonitorFilter
 
+# By design, __init__ is called inside miniterm and we can't pass context to it.
+# pylint: disable=attribute-defined-outside-init
 
 class Esp32ExceptionDecoder(DeviceMonitorFilter):
     NAME = "esp32_exception_decoder"
@@ -104,7 +103,7 @@ class Esp32ExceptionDecoder(DeviceMonitorFilter):
             sys.stderr.write("%s: failed to call %s: %s\n" %
                 (self.__class__.__name__, self.addr2line_path, e))
         return trace
-    
+
     def strip_project_dir(self, trace):
         while True:
             idx = trace.find(self.project_dir)


### PR DESCRIPTION
**Requires https://github.com/platformio/platformio-core/pull/3383.**

Adds a monitor filter that can decode esp32 exception traces, it looks like this with a debug build (the indented part is new): ![Screenshot_20200215_190846](https://user-images.githubusercontent.com/120108/74592997-39aff180-5027-11ea-998a-1b2ce128fef2.png)

It was tested on Linux with Python3 and Windows with Python 2 with `esp32dev` board. 

Add `--filter=esp32_exception_decoder` to your monitor_flags to activate it.

Fixes #105