### PR TITLE
Esp32ExceptionDecoder: fix compatibility with ESP-IDF 4.0

### DIFF
--- a/monitor/filter_exception_decoder.py
+++ b/monitor/filter_exception_decoder.py
@@ -32,7 +32,7 @@ class Esp32ExceptionDecoder(DeviceMonitorFilter):
     def __call__(self):
         self.buffer = ""
         self.backtrace_re = re.compile(
-            r"^Backtrace: ((0x[0-9a-f]+:0x[0-9a-f]+ ?)+)\s*$"
+            r"^Backtrace: ((0x[0-9a-f]+:0x[0-9a-f]+ ?)+)\s*"
         )
 
         self.firmware_path = None


### PR DESCRIPTION
One more fix for the decoder ESP-IDF 4.0 adds |<-CORRUPTED at the end of the backtrace:

```
Backtrace: 0x400803bd:0x3ffb6b10 0xfffffffe:0x3ffb6c00 |<-CORRUPTED
```