### PR TITLE
Esp32ExceptionDecoder: fix compatibility with esp-idf master

### DIFF
--- a/monitor/filter_exception_decoder.py
+++ b/monitor/filter_exception_decoder.py
@@ -32,7 +32,7 @@ class Esp32ExceptionDecoder(DeviceMonitorFilter):
     def __call__(self):
         self.buffer = ""
         self.backtrace_re = re.compile(
-            r"^Backtrace: ((0x[0-9a-f]+:0x[0-9a-f]+ ?)+)\s*"
+            r"^Backtrace: ?((0x[0-9a-f]+:0x[0-9a-f]+ ?)+)\s*"
         )
 
         self.firmware_path = None


### PR DESCRIPTION
ESP-IDF keeps changing the Backtrace format for some reason: https://github.com/espressif/esp-idf/commit/ee519634a5222d5fe86f8d51cb288f4cb7f9eb6d