### PR TITLE
heltec_wireless_stick_lite: Add board definition

### DIFF
--- a/boards/heltec_wireless_stick_lite.json
+++ b/boards/heltec_wireless_stick_lite.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_HELTEC_WIRELESS_STICK_LITE",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "partitions": "default.csv",
+    "variant": "heltec_wireless_stick_lite"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Heltec Wireless Stick Lite",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 1310720,
+    "maximum_size": 327680,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://heltec.org/project/wireless-stick-lite/",
+  "vendor": "Heltec Automation"
+}


### PR DESCRIPTION
Add board defitintion for Heltecs Wireless Stick Lite.
Product: https://heltec.org/project/wireless-stick-lite/

The patch is based on @brunohorta82 previous work.