### PR TITLE
Change define "ARDUINO_T-Watch" to "ARDUINO_T_Watch" prevent "warning: ISO C99 requires whitespace after the macro name"

### DIFF
--- a/boards/ttgo-t-watch.json
+++ b/boards/ttgo-t-watch.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_T-Watch -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
+    "extra_flags": "-DARDUINO_T_Watch -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",


### PR DESCRIPTION
Change define "ARDUINO_T-Watch" to "ARDUINO_T_Watch" prevent "warning: ISO C99 requires whitespace after the macro name"