### PR TITLE
fix the AZ-Delivery ESP-32 Dev Kit C V4 flash size

### DIFF
--- a/boards/az-delivery-devkit-v4.json
+++ b/boards/az-delivery-devkit-v4.json
@@ -26,7 +26,7 @@
   ],
   "name": "AZ-Delivery ESP-32 Dev Kit C V4",
   "upload": {
-    "flash_size": "16MB",
+    "flash_size": "4MB",
     "maximum_ram_size": 532480,
     "maximum_size": 16777216,
     "require_upload_port": true,


### PR DESCRIPTION
I'm not sure that this merge will eventually and automatically update the documentation at https://docs.platformio.org/en/latest/boards/espressif32/az-delivery-devkit-v4.html

If it doesn't, you also need to merge https://github.com/platformio/platformio-docs/pull/145


for reference, this board has a 32-Mbit flash which corresponds to 4-MBytes, as you can see with `esptool.py`:

```
$ esptool.py -p /dev/ttyUSB0 flash_id

esptool.py v2.8
Serial port /dev/ttyUSB0
Connecting....
Detecting chip type... ESP32
Chip is ESP32D0WDQ6 (revision 1)
Features: WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 24:62:ab:e0:29:3c
Uploading stub...
Running stub...
Stub running...
Manufacturer: 5e
Device: 4016
Detected flash size: 4MB
Hard resetting via RTS pin...
```
