### PR TITLE
Create ttgo-t-call-sim800

### DIFF
--- a/boards/ttgo-t-call-sim800.json
+++ b/boards/ttgo-t-call-sim800.json
@@ -1,0 +1,37 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_T_Beam -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "t-call-sim800"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "can",
+    "ethernet"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "TTGO T-Call-SIM800",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 1310720,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://github.com/Xinyuan-LilyGO/LilyGo-T-Call-SIM800",
+  "vendor": "TTGO"
+}


### PR DESCRIPTION
Add board definition for [TTGO-T-Call-SIM800 ](https://github.com/Xinyuan-LilyGO/LilyGo-T-Call-SIM800). The definition is based on comparable board [ttgo-t-beam](https://github.com/platformio/platform-espressif32/blob/develop/boards/ttgo-t-beam.json). 
