### PR TITLE
Added Board TTGO-LoRA32-v2.1.6

### DIFF
--- a/boards/ttgo-lora32-v21new.json
+++ b/boards/ttgo-lora32-v21new.json
@@ -1,0 +1,37 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_TTGO_LoRa32_V21new",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "ttgo-lora32-v21new"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "TTGO LoRa32-OLED V2.1.6",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://github.com/LilyGO/TTGO-LORA32-V2.1",
+  "vendor": "TTGO"
+ }

--- a/boards/ttgo-lora32-v21new.json
+++ b/boards/ttgo-lora32-v21new.json
@@ -35,3 +35,4 @@
   "url": "https://github.com/LilyGO/TTGO-LORA32-V2.1",
   "vendor": "TTGO"
  }
+ 


### PR DESCRIPTION
Board is now availabe also in Arduino-Framework: http://github.com/espressif/arduino-esp32 so ready for merging