### PR TITLE
added option to override fw app offset when customizing partition table

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -310,11 +310,12 @@ elif upload_protocol == "esptool":
             "--flash_freq", "${__get_board_f_flash(__env__)}",
             "--flash_size", "detect"
         ],
-        UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS 0x10000 $SOURCE'
+        UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS $SOURCE'
     )
     for image in env.get("FLASH_EXTRA_IMAGES", []):
         env.Append(UPLOADERFLAGS=[image[0], env.subst(image[1])])
-
+    env.Append(UPLOADERFLAGS=board.get("upload.offset_address", "0x10000"))
+    
     if "uploadfs" in COMMAND_LINE_TARGETS:
         env.Replace(
             UPLOADERFLAGS=[


### PR DESCRIPTION
added option to override fw app offset when customizing partition table offset ( was always fixed to 0x10000 in esptool upload methode ) -> changed to adapt to option :  board_upload.offset_address= x