### PR TITLE
Replace '-' in macro name with '_' for board "TTGO T-Watch"

### DIFF
--- a/boards/ttgo-t-watch.json
+++ b/boards/ttgo-t-watch.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_T-Watch -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
+    "extra_flags": "-DARDUINO_T_Watch -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",


### PR DESCRIPTION
Replace '-' in macro name with '_' for board "TTGO T-Watch"

Fixes compiler warnings:

    <command-line>:0:10: warning: ISO C++11 requires whitespace after the macro name

This is similar to #81