### PR TITLE
Use a "safe" value for OpenOCD adapter speed

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -125,7 +125,7 @@ class Espressif32Platform(PlatformBase):
                 "-s", "$PACKAGE_DIR/share/openocd/scripts",
                 "-f", "interface/%s.cfg" % openocd_interface,
                 "-f", "board/%s" % debug.get("openocd_board"),
-                "-c", "adapter_khz %d" % debug.get("adapter_speed", 20000)
+                "-c", "adapter_khz %d" % debug.get("adapter_speed", 5000)
             ]
 
             debug['tools'][link] = {


### PR DESCRIPTION
@maxgerhardt opened an issue to make the adapter speed configurable via `platformio.ini` (see #459), but until that's possible, I think it would be best to set a "safe" speed by default.