### PR TITLE
Fix invalid ARDUINO_x macro name for ttgo watch board

### DIFF
--- a/boards/ttgo-t-watch.json
+++ b/boards/ttgo-t-watch.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_T-Watch -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
+    "extra_flags": "-DARDUINO_TWatch -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",


### PR DESCRIPTION
1. Macro name was invalid since [there must never ever be a `-` in the name of a macro](https://stackoverflow.com/a/369524/5296568)
2. Macro name was wrong because Arduino-ESP32 uses `-DARDUINO_TWatch` as can be seen in https://github.com/espressif/arduino-esp32/blob/2452c1fb539246e47a715b74a3ad25b8a7ebbec7/boards.txt#L4537-L4550 and https://github.com/espressif/arduino-esp32/blob/2452c1fb539246e47a715b74a3ad25b8a7ebbec7/platform.txt#L75

Fixes 

```
<command-line>:0:10: warning: ISO C++11 requires whitespace after the macro name
```

warnings when compiling for this board.