### PR TITLE
Add Lolin32 Lite and TTGO T7 boards

### DIFF
--- a/boards/lolin32-lite.json
+++ b/boards/lolin32-lite.json
@@ -1,0 +1,34 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_LOLIN32_Lite",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "lolin32"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "WEMOS LOLIN32 Lite",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 532480,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://web.archive.org/web/20191002041532/https://wiki.wemos.cc/products:lolin32:lolin32_lite",
+  "vendor": "WEMOS"
+}

--- a/boards/ttgo-t7-v13-mini32.json
+++ b/boards/ttgo-t7-v13-mini32.json
@@ -1,0 +1,34 @@
+{
+  "build": {
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_TTGO_T7_V13_Mini32",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "mcu": "esp32",
+    "variant": "ttgo-t7-v13-mini32"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "TTGO T7 V1.3 Mini32",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 532480,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://github.com/LilyGO/ESP32-MINI-32-V1.3",
+  "vendor": "TTGO"
+}

--- a/boards/ttgo-t7-v14-mini32.json
+++ b/boards/ttgo-t7-v14-mini32.json
@@ -1,0 +1,37 @@
+{
+  "build": {
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_TTGO_T7_V14_Mini32",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "mcu": "esp32",
+    "variant": "ttgo-t7-v14-mini32"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_board": "esp32-wrover.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "TTGO T7 V1.3 Mini32",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 532480,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://github.com/LilyGO/TTGO-T7-Demo",
+  "vendor": "TTGO"
+}


### PR DESCRIPTION
Add Wemos Lolin32 Lite (original no longer being produced, same as Lolin32), TTGO
T7 v1.3 and v1.4 boards (status unknown).  All three are rather generic ESP32 boards the
main difference being pin layout.

I use these from ESPHome which relies on the platformio board definitions.  On top of it ESPHome has a per-board pin assignemtn registry (status LED pin, VBAT pin, etc.) where these boards actually differ.