### PR TITLE
Upload fails on m5stack atom lite when speed is 460800

### DIFF
--- a/boards/m5stack-atom.json
+++ b/boards/m5stack-atom.json
@@ -27,7 +27,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 115200
+    "speed": 1500000
   },
   "url": "http://www.m5stack.com",
   "vendor": "M5Stack"

--- a/boards/m5stack-atom.json
+++ b/boards/m5stack-atom.json
@@ -27,7 +27,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 460800
+    "speed": 115200
   },
   "url": "http://www.m5stack.com",
   "vendor": "M5Stack"


### PR DESCRIPTION
The upload to m5stack atom lite fails, when the baud rate is 460800.
```
Connecting....
Chip is ESP32-PICO-D4 (revision 1)
Features: WiFi, BT, Dual Core, 240MHz, Embedded Flash, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 24:a1:60:46:20:e4
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 460800
Changed.
Configuring flash size...

A fatal error occurred: Timed out waiting for packet header
*** [upload] Error 2
```