### PR TITLE
Add uPesy ESP32 boards (uPesy ESP32 Wroom and Wrover DevKit)  support on PIO 

### DIFF
--- a/boards/upesy-esp32-wroom.json
+++ b/boards/upesy-esp32-wroom.json
@@ -1,0 +1,37 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_ESP32_DEV -D LED_BUILTIN=2",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "qio",
+    "mcu": "esp32",
+    "variant": "esp32"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "uPesy ESP32 Wroom Devkit",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://learn.upesy.com/",
+  "vendor": "uPesy Electronics"
+}

--- a/boards/upesy-esp32-wrover.json
+++ b/boards/upesy-esp32-wrover.json
@@ -1,0 +1,37 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_ESP32_WROVER -D LED_BUILTIN=2 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "qio",
+    "mcu": "esp32",
+    "variant": "esp32"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "uPesy ESP32 Wrover Devkit",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://learn.upesy.com/",
+  "vendor": "uPesy Electronics"
+}


### PR DESCRIPTION
Please add uPesy ESP32 boards support on PlatformIO:
[https://learn.upesy.com/en/boards/cartes_ESP32_uPesy.html](https://learn.upesy.com/en/boards/cartes_ESP32_uPesy.html)