### PR TITLE
Esp32ExceptionDecoder: support uppercase hex addresses in backtrace

### DIFF
--- a/monitor/filter_exception_decoder.py
+++ b/monitor/filter_exception_decoder.py
@@ -32,7 +32,7 @@ class Esp32ExceptionDecoder(DeviceMonitorFilter):
     def __call__(self):
         self.buffer = ""
         self.backtrace_re = re.compile(
-            r"^Backtrace: ?((0x[0-9a-f]+:0x[0-9a-f]+ ?)+)\s*"
+            r"^Backtrace: ?((0x[0-9a-fA-F]+:0x[0-9a-fA-F]+ ?)+)\s*"
         )
 
         self.firmware_path = None


### PR DESCRIPTION
In some ESP-IDF version, after calling `esp_backtrace_print`, the backtrace is in uppercase.