### PR TITLE
boards: add arduino support to ESP32-C3-DevKitM-1

### DIFF
--- a/boards/esp32-c3-devkitm-1.json
+++ b/boards/esp32-c3-devkitm-1.json
@@ -17,6 +17,7 @@
     "openocd_target": "esp32c3.cfg"
   },
   "frameworks": [
+    "arduino",
     "espidf"
   ],
   "name": "Espressif ESP32-C3-DevKitM-1",


### PR DESCRIPTION
Without this, the board cannot be used in ESPHome.