### PR TITLE
Fix AWS IoT demo output parsing

### DIFF
--- a/examples/espidf-aws-iot/platformio.ini
+++ b/examples/espidf-aws-iot/platformio.ini
@@ -12,6 +12,7 @@ platform = espressif32
 framework = espidf
 board = esp32dev
 monitor_speed = 115200
+monitor_filters = colorize
 
 board_build.embed_txtfiles = 
   src/certs/private.pem.key


### PR DESCRIPTION
The demonstration builds and runs on the ESP32 outputting
escape codes which are not parsed by default. This makes
the output hard to read.

This PR sets platform.io to correctly parse the escape codes.