### PR TITLE
Changed flash mode from QIO to DIO 

### DIFF
--- a/boards/tinypico.json
+++ b/boards/tinypico.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DARDUINO_TINYPICO -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
-    "flash_mode": "qio",
+    "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "pico32"
   },
@@ -21,7 +21,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "TinyPICO",
+  "name": "UM TinyPICO",
   "upload": {
     "flash_size": "4MB",
     "maximum_ram_size": 327680,
@@ -30,5 +30,5 @@
     "speed": 460800
   },
   "url": "https://www.tinypico.com",
-  "vendor": "TinyPICO"
+  "vendor": "Unexpected Maker"
 }


### PR DESCRIPTION
This change is to prevent code boot issues for folks using TinyPICO on PlatformIO
I am not sure what has changed under the hood (in ESP32 Arduino Core) but folks are no longer able to flash using QIO flash mode without getting this on board reboot...

```[22:25:56]rst:0x10 (RTCWDT_RTC_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
[22:25:56]configsip: 188777542, SPIWP:0xee
[22:25:56]clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
[22:25:56]mode:QIO, clock div:2
[22:25:56]load:0x3fff0018,len:4
[22:25:56]load:0xfcddccec,len:-822218804
[22:25:56]1162 mmu set 00010000, pos 00010000
[22:25:56]1162 mmu set 00020000, pos 00020000
[22:25:56]1162 mmu set 00030000, pos 00030000
[22:25:56]1162 mmu set 00040000, pos 00040000
[22:25:56]1162 mmu set 00050000, pos 00050000
[22:25:56]1162 mmu set 00060000, pos 00060000
[22:25:56]1162 mmu set 00070000, pos 00070000
[22:25:56]1162 mmu set 00080000, pos 00080000
[22:25:56]1162 mmu set 00090000, pos 00090000
[22:25:56]1162 mmu set 000a0000, pos 000a0000
[22:25:56]1162 mmu set 000b0000, pos 000b0000
[22:25:56]1162 mmu set 000c0000, pos 000c0000
[22:25:56]1162 mmu set 000d0000, pos 000d0000
[22:25:56]1162 mmu set 000e0000, pos 000e0000
[22:25:56]ets Jun  8 2016 00:22:57
```