### PR TITLE
Use DIO instead of QIO

### DIFF
--- a/boards/esp32-c3-devkitm-1.json
+++ b/boards/esp32-c3-devkitm-1.json
@@ -6,7 +6,7 @@
     "core": "esp32",
     "f_cpu": "160000000L",
     "f_flash": "80000000L",
-    "flash_mode": "qio",
+    "flash_mode": "dio",
     "mcu": "esp32c3",
     "variant": "esp32c3"
   },


### PR DESCRIPTION
With current Arduino master (which equates to Espressif ESP32 Arduino
2.0.0 release) using QIO leads to a boot loop on ESP32-C3 devices.
Use DIO which seems to work.

Fixes: #622 