### PR TITLE
Add Franzininho WiFi Board

### DIFF
--- a/boards/esp32-s2-franzininho.json
+++ b/boards/esp32-s2-franzininho.json
@@ -1,0 +1,32 @@
+{
+  "build": {
+    "arduino":{
+      "ld": "esp32s2_out.ld"
+    },
+    "core": "esp32",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32s2",
+    "variant": "esp32s2"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s2.cfg"
+  },
+  "frameworks": [
+    "espidf"
+  ],
+  "name": "Franzininho WiFi Board",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://github.com/Franzininho/Franzininho-WIFI",
+  "vendor": "Franzininho"
+}


### PR DESCRIPTION
Franzininho WiFi Board is a development board to evaluate ESP32-S2 Modules (Wroom and Wrover) and develop the new generation of Franzininho Boards. The Franzininho project was created to develop skills in people in the areas of electronics and programming, through activities in the DIY format and in conjunction with maker culture in Brazil.

Project: https://github.com/Franzininho/Franzininho-WIFI

The project is an open-source hardware and is available on CERN open hardware license.

The Franzininho WiFi board is certified in OSHWA: UID BR000006