### PR TITLE
esp32_exception_decoder: fix decoding when space is missing

### DIFF
--- a/monitor/filter_exception_decoder.py
+++ b/monitor/filter_exception_decoder.py
@@ -32,7 +32,7 @@ class Esp32ExceptionDecoder(DeviceMonitorFilter):
     def __call__(self):
         self.buffer = ""
         self.backtrace_re = re.compile(
-            r"^Backtrace: ?((0x[0-9a-fA-F]+:0x[0-9a-fA-F]+ ?)+)\s*"
+            r"^Backtrace: ?((0x[0-9a-fA-F]{8}:0x[0-9a-fA-F]{8} ?)+)\s*"
         )
 
         self.firmware_path = None


### PR DESCRIPTION
Host: MacOS Big Sur 11.6
Target: M5Stack core2
platformio.ini:    
    monitor_filters = direct,   esp32_exception_decoder

The backtrace message lacks a space after the top-of-stack address,
consequently the backtrace regex does not trigger and backtrace not shown.


> Backtrace:0x40083161:0x3ffb24700x40089315:0x3ffb2490 0x4008de89:0x3ffb24b0
> ------ missing space --------------^ 


by replacing the  '+' (1..n )length of hex addresses by fixed repeat count of 8, 
these backtraces can be made to decode correctly.

While the error in the message seems specific to the M5Stack Core2, the patch does no harm if the format is correct.

as per 495c689133146ef8d4520d8ff3b10a720508a0c8  - backtrace not decoded:
```
> Executing task: platformio device monitor <

source /Users/mah/.platformio/penv/bin/activate
--- Available filters and text transformations: colorize, debug, default, direct, esp32_exception_decoder, hexlify, log2file, mah_exception_decoder, nocontrol, printable, send_on_enter, time
--- More details at https://bit.ly/pio-monitor-filters
Esp32ExceptionDecoder: firmware at /Users/mah/Documents/PlatformIO/Projects-private/m5core2-lvgl-demo/.pio/build/m5stack-core2/firmware.elf does not exist, rebuild the project?
--- Miniterm on /dev/cu.SLAB_USBtoUART  115200,8,N,1 ---
--- Quit: Ctrl+C | Menu: Ctrl+T | Help: Ctrl+T followed by Ctrl+H ---
Hello Arduino! V8.1.1
I am LVGL_Arduino
Setup done

assert failed: xQueueGenericSend queue.c:820 (pxQueue)


Backtrace:0x40083161:0x3ffb24700x40089315:0x3ffb2490 0x4008de89:0x3ffb24b0 0x40089ade:0x3ffb25e0 0x4011367a:0x3ffb2620 0x401137b5:0x3ffb2640 0x400d5e27:0x3ffb2660 0x400d5ed2:0x3ffb2680 0x400d6008:0x3ffb26d0 0x400d147c:0x3ffb2720 0x400e98c5:0x3ffb2760 0x400d7fc9:0x3ffb2780 0x400eac62:0x3ffb27c0 0x400ead0a:0x3ffb27e0 0x400d169f:0x3ffb2800 0x40104ae5:0x3ffb2820 




ELF file SHA256: 0000000000000000

Rebooting...
````

with this patch applied, the backtrace decodes correctly:

````
> Executing task: platformio device monitor <

--- Available filters and text transformations: colorize, debug, default, direct, esp32_exception_decoder, hexlify, log2file, mah_exception_decoder, nocontrol, printable, send_on_enter, time
--- More details at https://bit.ly/pio-monitor-filters
--- Logging an output to /Users/mah/Documents/PlatformIO/Projects-private/m5core2-lvgl-demo/platformio-device-monitor-211214-181147.log
--- Miniterm on /dev/cu.SLAB_USBtoUART  115200,8,N,1 ---
--- Quit: Ctrl+C | Menu: Ctrl+T | Help: Ctrl+T followed by Ctrl+H ---
Hello Arduino! V8.1.1
I am LVGL_Arduino
Setup done

assert failed: xQueueGenericSend queue.c:820 (pxQueue)


Backtrace:0x40083161:0x3ffb24700x40089315:0x3ffb2490 0x4008de89:0x3ffb24b0 0x40089ade:0x3ffb25e0 0x4011367a:0x3ffb2620 0x401137b5:0x3ffb2640 0x400d5e27:0x3ffb2660 0x400d5ed2:0x3ffb2680 0x400d6008:0x3ffb26d0 0x400d147c:0x3ffb2720 0x400e98c5:0x3ffb2760 0x400d7fc9:0x3ffb2780 0x400eac62:0x3ffb27c0 0x400ead0a:0x3ffb27e0 0x400d169f:0x3ffb2800 0x40104ae5:0x3ffb2820 
  #0  0x40083161:0x3ffb24700x40089315:0x3ffb2490 in panic_abort at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/esp_system/panic.c:402
  #1  0x4008de89:0x3ffb24b0 in __assert_func at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/newlib/assert.c:85
  #2  0x40089ade:0x3ffb25e0 in xQueueGenericSend at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/freertos/queue.c:821 (discriminator 2)
  #3  0x4011367a:0x3ffb2620 in TwoWire::endTransmission(bool) at /Users/mah/.platformio/packages/framework-arduinoespressif32/libraries/Wire/src/Wire.cpp:339
  #4  0x401137b5:0x3ffb2640 in TwoWire::endTransmission() at /Users/mah/.platformio/packages/framework-arduinoespressif32/libraries/Wire/src/Wire.cpp:498
  #5  0x400d5e27:0x3ffb2660 in M5Touch::ft6336(unsigned char, unsigned char, unsigned char*) at .pio/libdeps/m5stack-core2/M5Core2/src/M5Touch.cpp:54
  #6  0x400d5ed2:0x3ffb2680 in M5Touch::read() at .pio/libdeps/m5stack-core2/M5Core2/src/M5Touch.cpp:88
  #7  0x400d6008:0x3ffb26d0 in M5Touch::getPressPoint() at .pio/libdeps/m5stack-core2/M5Core2/src/M5Touch.cpp:124
  #8  0x400d147c:0x3ffb2720 in my_touchpad_read(_lv_indev_drv_t*, lv_indev_data_t*) at src/LVGL_Arduino.cpp:57
  #9  0x400e98c5:0x3ffb2760 in _lv_indev_read at lib/lvgl/src/hal/lv_hal_indev.c:187
  #10 0x400d7fc9:0x3ffb2780 in lv_indev_read_timer_cb at lib/lvgl/src/core/lv_indev.c:82
  #11 0x400eac62:0x3ffb27c0 in lv_timer_exec at lib/lvgl/src/misc/lv_timer.c:313 (discriminator 2)
  #12 0x400ead0a:0x3ffb27e0 in lv_timer_handler at lib/lvgl/src/misc/lv_timer.c:109
  #13 0x400d169f:0x3ffb2800 in loop() at src/LVGL_Arduino.cpp:136
  #14 0x40104ae5:0x3ffb2820 in loopTask(void*) at /Users/mah/.platformio/packages/framework-arduinoespressif32/cores/esp32/main.cpp:46




ELF file SHA256: 0000000000000000

Rebooting...
````

