### PR TITLE
add board Wireless-Tag WT32-ETH01 (wt32-eth01)

### DIFF
--- a/boards/wt32-eth01.json
+++ b/boards/wt32-eth01.json
@@ -1,43 +1,39 @@
 {
-    "build": {
-        "arduino": {
-            "ldscript": "esp32_out.ld"
-        },
-        "core": "esp32",
-        "extra_flags": [
-            "-DARDUINO_WT32_ETH01"
-        ],
-        "f_cpu": "240000000L",
-        "f_flash": "40000000L",
-        "flash_mode": "dio",
-        "boot": "dio",
-        "mcu": "esp32",
-        "variant": "wt32-eth01"
+  "build": {
+    "arduino": {
+      "ldscript": "esp32_out.ld"
     },
-    "connectivity": [
-        "wifi",
-        "bluetooth",
-        "ethernet",
-        "can"
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_WT32_ETH01"
     ],
-    "debug": {
-        "openocd_board": "esp-wroom-32.cfg"
-    },
-    "frameworks": [
-        "arduino",
-        "espidf"
-    ],
-    "platforms": [
-        "espressif32"
-    ],
-    "name": "WT32-ETH01 Ethernet Module",
-    "upload": {
-        "flash_size": "4MB",
-        "maximum_ram_size": 327680,
-        "maximum_size": 4194304,
-        "require_upload_port": true,
-        "speed": 460800
-    },
-    "url": "http://www.wireless-tag.com/portfolio/wt32-eth01/",
-    "vendor": "Wireless-Tag"
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "wt32-eth01"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Wireless-Tag WT32-ETH01 Ethernet Module",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "http://www.wireless-tag.com/portfolio/wt32-eth01/",
+  "vendor": "Wireless-Tag"
 }

--- a/boards/wt32-eth01.json
+++ b/boards/wt32-eth01.json
@@ -1,0 +1,43 @@
+{
+    "build": {
+        "arduino": {
+            "ldscript": "esp32_out.ld"
+        },
+        "core": "esp32",
+        "extra_flags": [
+            "-DARDUINO_WT32_ETH01"
+        ],
+        "f_cpu": "240000000L",
+        "f_flash": "40000000L",
+        "flash_mode": "dio",
+        "boot": "dio",
+        "mcu": "esp32",
+        "variant": "wt32-eth01"
+    },
+    "connectivity": [
+        "wifi",
+        "bluetooth",
+        "ethernet",
+        "can"
+    ],
+    "debug": {
+        "openocd_board": "esp-wroom-32.cfg"
+    },
+    "frameworks": [
+        "arduino",
+        "espidf"
+    ],
+    "platforms": [
+        "espressif32"
+    ],
+    "name": "WT32-ETH01 Ethernet Module",
+    "upload": {
+        "flash_size": "4MB",
+        "maximum_ram_size": 327680,
+        "maximum_size": 4194304,
+        "require_upload_port": true,
+        "speed": 460800
+    },
+    "url": "http://www.wireless-tag.com/portfolio/wt32-eth01/",
+    "vendor": "Wireless-Tag"
+}


### PR DESCRIPTION
Added board definition for WT32-ETH01 from Wireless-Tag (see http://www.wireless-tag.com/portfolio/wt32-eth01/)

- the corresponding variant `wt32-eth01` was recently added to https://github.com/espressif/arduino-esp32
- the variant includes the pin definitions for Ethernet PHY (LAN8720A)
- tested: works out-of-the-box with AsyncTCP and ESPAsyncWebServer