### PR TITLE
Use gcc-ar and gcc-ranlib

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -146,14 +146,14 @@ env.Replace(
     __get_board_f_flash=_get_board_f_flash,
     __get_board_flash_mode=_get_board_flash_mode,
 
-    AR="%s-elf-ar" % toolchain_arch,
+    AR="%s-elf-gcc-ar" % toolchain_arch,
     AS="%s-elf-as" % toolchain_arch,
     CC="%s-elf-gcc" % toolchain_arch,
     CXX="%s-elf-g++" % toolchain_arch,
     GDB="%s-elf-gdb" % toolchain_arch,
     OBJCOPY=join(
         platform.get_package_dir("tool-esptoolpy") or "", "esptool.py"),
-    RANLIB="%s-elf-ranlib" % toolchain_arch,
+    RANLIB="%s-elf-gcc-ranlib" % toolchain_arch,
     SIZETOOL="%s-elf-size" % toolchain_arch,
 
     ARFLAGS=["rc"],


### PR DESCRIPTION
In order to use link time optimizations (lto) `ar` and `ranlib` need to have the lto plugin supplied. This is achieved easiest by using the `gcc-*` equivalents. More info:
https://embeddedartistry.com/blog/2020/04/13/prefer-gcc-ar-to-ar-in-your-buildsystems/
This won't affect most builds at all, because lto [is disabled in the framework package](https://github.com/espressif/arduino-esp32/blob/master/tools/platformio-build-esp32.py#L83). As far as I've found this setting comes from https://github.com/espressif/esp-idf/issues/3989 and is more of a hotfix for Mac builds than a needed change.

I've successfully enabled lto in [my project](https://github.com/TheRealMazur/LinakDeskEsp32Controller/commit/79d6403a0d6f9f4d41c015a49761c870867d9181) without any functional differences, achieving ~5% flash usage reduction.