### PR TITLE
Support for ESP-IDF 4.4.0

### DIFF
--- a/boards/esp32-s3-devkitc-1.json
+++ b/boards/esp32-s3-devkitc-1.json
@@ -1,0 +1,32 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld"
+    },
+    "core": "esp32",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "espidf"
+  ],
+  "name": "Espressif ESP32-S3-DevKitC-1",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 524288,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html",
+  "vendor": "Espressif"
+}

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -55,7 +55,7 @@ TOOLCHAIN_DIR = platform.get_package_dir(
     % (
         "riscv32-esp"
         if mcu == "esp32c3"
-        else ("xtensa-esp32s2" if mcu == "esp32s2" else "xtensa-esp32")
+        else ("xtensa-%s" % mcu)
     )
 )
 
@@ -233,7 +233,13 @@ def populate_idf_env_vars(idf_env):
 
     if mcu != "esp32c3":
         additional_packages.append(
-            os.path.join(platform.get_package_dir("toolchain-%sulp" % mcu), "bin"),
+            os.path.join(
+                platform.get_package_dir(
+                    "toolchain-%sulp"
+                    % ("esp32s2" if mcu == "esp32s3" else mcu)
+                ),
+                "bin"
+              ),
         )
 
     if "windows" in get_systype():

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -452,24 +452,9 @@ def find_framework_service_files(search_path, sdk_config):
 
     result["lf_files"].extend(
         [
-            os.path.join(
-                FRAMEWORK_DIR,
-                "components",
-                "esp_common",
-                "common.lf"),
-
-            os.path.join(
-                FRAMEWORK_DIR,
-                "components",
-                "esp_common",
-                "soc.lf"),
-
-            os.path.join(
-                FRAMEWORK_DIR,
-                "components",
-                "esp_system",
-                "app.lf"),
-
+            os.path.join(FRAMEWORK_DIR, "components", "esp_common", "common.lf"),
+            os.path.join(FRAMEWORK_DIR, "components", "esp_common", "soc.lf"),
+            os.path.join(FRAMEWORK_DIR, "components", "esp_system", "app.lf"),
             os.path.join(FRAMEWORK_DIR, "components", "newlib", "newlib.lf"),
             os.path.join(FRAMEWORK_DIR, "components", "newlib", "system_libs.lf"),
         ]
@@ -528,7 +513,8 @@ def generate_project_ld_script(sdk_config, ignore_targets=None):
             "bin",
             env.subst("$CC")),
         "ld_output": os.path.join("$BUILD_DIR", "memory.ld"),
-        "ld_dir": os.path.join(FRAMEWORK_DIR,
+        "ld_dir": os.path.join(
+            FRAMEWORK_DIR,
             "components",
             "esp_system",
             "ld"),
@@ -540,15 +526,14 @@ def generate_project_ld_script(sdk_config, ignore_targets=None):
             idf_variant,
             "memory.ld.in",
         ),
-        "project_output": os.path.join("$BUILD_DIR", "%s.project.ld" % idf_variant),
         "config": os.path.join("$BUILD_DIR", "config"),
-        "flags" : '-C -P -x c -E -o ' 
+        "flags" : '-C -P -x c -E -o '
     }
-    
+
     cmd = (
         '"{preprocess}" {flags} "{ld_output}" -I "{config}" -I "{ld_dir}" "{ld_input}"'
     ).format(**args)
-    
+
     env.Command(
         os.path.join("$BUILD_DIR", "memory.ld"),
         os.path.join(
@@ -565,18 +550,10 @@ def generate_project_ld_script(sdk_config, ignore_targets=None):
     args = {
         "script": os.path.join(FRAMEWORK_DIR, "tools", "ldgen", "ldgen.py"),
         "config": SDKCONFIG_PATH,
-        "fragments": "".join(['%s;' % f for f in project_files.get("lf_files")]).strip(';'),
+        "fragments": " ".join(['"%s"' % f for f in project_files.get("lf_files")]),
         "kconfig": os.path.join(FRAMEWORK_DIR, "Kconfig"),
         "env_file": os.path.join("$BUILD_DIR", "config.env"),
         "libraries_list": libraries_list,
-        "section_input": os.path.join(
-            FRAMEWORK_DIR,
-            "components",
-            "esp_system",
-            "ld",
-            idf_variant,
-            "sections.ld.in",
-        ),
         "objdump": os.path.join(
             TOOLCHAIN_DIR,
             "bin",
@@ -586,7 +563,7 @@ def generate_project_ld_script(sdk_config, ignore_targets=None):
 
     cmd = (
         '"$PYTHONEXE" "{script}" --input $SOURCE '
-        '--config "{config}" --fragments-list "{fragments}" --output $TARGET '
+        '--config "{config}" --fragments {fragments} --output $TARGET '
         '--kconfig "{kconfig}" --env-file "{env_file}" '
         '--libraries-file "{libraries_list}" '
         '--objdump "{objdump}"'
@@ -762,7 +739,7 @@ def fix_ld_paths(extra_flags):
     peripheral_framework_path = os.path.join(FRAMEWORK_DIR, "components", "soc", idf_variant, "ld")
     rom_framework_path = os.path.join(FRAMEWORK_DIR, "components", "esp_rom", idf_variant, "ld")
     bl_framework_path = os.path.join(FRAMEWORK_DIR, "components", "bootloader", "subproject", "main", "ld", idf_variant)
-    
+
     # ESP linker scripts changed path in ESP-IDF 4.4+, so add missing paths to linker's search path
     try:
         ld_index = extra_flags.index("%s.peripherals.ld" % idf_variant)
@@ -1139,8 +1116,8 @@ if not board.get("build.ldscript", ""):
             ),
         ),
         env.VerboseAction(
-            '$CC -I"$BUILD_DIR/config" -I"' + 
-            os.path.join(FRAMEWORK_DIR, "components", "esp_system", "ld") + 
+            '$CC -I"$BUILD_DIR/config" -I"' +
+            os.path.join(FRAMEWORK_DIR, "components", "esp_system", "ld") +
             '" -C -P -x  c -E $SOURCE -o $TARGET',
             "Generating LD script $TARGET",
         ),

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1376,7 +1376,7 @@ env.Prepend(
     FLASH_EXTRA_IMAGES=[
         (
             board.get(
-                "upload.bootloader_offset", "0x0" if mcu == "esp32c3" else "0x1000"
+                "upload.bootloader_offset", "0x0" if (mcu == "esp32c3" or mcu == "esp32s3") else "0x1000"
             ),
             os.path.join("$BUILD_DIR", "bootloader.bin"),
         ),

--- a/platform.json
+++ b/platform.json
@@ -93,7 +93,7 @@
       "type": "toolchain",
       "optional": true,
       "owner": "espressif",
-      "version": "8.4.0+2021r2"
+      "version": "8.4.0+2021r2-patch2"
     },
     "toolchain-riscv32-esp": {
       "type": "toolchain",

--- a/platform.json
+++ b/platform.json
@@ -89,6 +89,12 @@
       "owner": "espressif",
       "version": "8.4.0+2021r2-patch2"
     },
+    "toolchain-xtensa-esp32s3": {
+      "type": "toolchain",
+      "optional": true,
+      "owner": "espressif",
+      "version": "8.4.0+2021r2"
+    },
     "toolchain-riscv32-esp": {
       "type": "toolchain",
       "optional": true,

--- a/platform.json
+++ b/platform.json
@@ -117,7 +117,7 @@
       "type": "framework",
       "optional": true,
       "owner": "platformio",
-      "version": "~3.40302.0",
+      "version": "~3.40400.0",
       "optionalVersions": ["~3.40001.0"]
     },
     "framework-simba": {

--- a/platform.py
+++ b/platform.py
@@ -84,9 +84,11 @@ class Espressif32Platform(PlatformBase):
             self.packages[xtensa32s2_toolchain]["optional"] = True
             self.packages["toolchain-xtensa-esp32s3"]["optional"] = True
             self.packages[riscv_toolchain]["optional"] = True
+            self.packages.pop("toolchain-esp32s2ulp", None)
         if mcu in ("esp32s2", "esp32s3", "esp32c3"):
             self.packages.pop(xtensa32_toolchain, None)
             self.packages.pop("toolchain-esp32ulp", None)
+            self.packages["toolchain-esp32s2ulp"]["optional"] = False
             # RISC-V based toolchain for ESP32C3 and ESP32S2 ULP
             self.packages[riscv_toolchain]["optional"] = False
             if mcu == "esp32s2":

--- a/platform.py
+++ b/platform.py
@@ -75,17 +75,26 @@ class Espressif32Platform(PlatformBase):
             for toolchain in (
                 "toolchain-xtensa-esp32",
                 "toolchain-xtensa-esp32s2",
+                "toolchain-xtensa-esp32s3",
                 "toolchain-riscv32-esp",
             ):
                 self.packages.pop(toolchain, None)
 
-        if mcu in ("esp32s2", "esp32c3"):
+        if mcu == "esp32":
+            self.packages[xtensa32s2_toolchain]["optional"] = True
+            self.packages["toolchain-xtensa-esp32s3"]["optional"] = True
+            self.packages[riscv_toolchain]["optional"] = True
+        if mcu in ("esp32s2", "esp32s3", "esp32c3"):
             self.packages.pop(xtensa32_toolchain, None)
             self.packages.pop("toolchain-esp32ulp", None)
             # RISC-V based toolchain for ESP32C3 and ESP32S2 ULP
             self.packages[riscv_toolchain]["optional"] = False
             if mcu == "esp32s2":
                 self.packages[xtensa32s2_toolchain]["optional"] = False
+                self.packages["toolchain-xtensa-esp32s3"]["optional"] = True
+            if mcu == "esp32s3":
+                self.packages["toolchain-xtensa-esp32s3"]["optional"] = False
+                self.packages[xtensa32s2_toolchain]["optional"] = True
 
         build_core = variables.get(
             "board_build.core", board_config.get("build.core", "arduino")


### PR DESCRIPTION
Espressif has released a stable version of V4.4
https://github.com/espressif/esp-idf/releases/tag/v4.4

"Forked" from this pull-request: https://github.com/platformio/platform-espressif32/pull/693
I've rebased it onto the current develop and fix the latest toolchain references.
**All credits for the work go to @X-Ryl669 and @jonathandreyer !**

Can be tested using the following config:
```
[env]
platform = https://github.com/FaBjE/platform-espressif32.git#espidf-440 
framework = espidf
platform_packages =
  ; use upstream forked ESP-IDF to use V4.4 until official platformIO package is released
  framework-espidf@https://github.com/FaBjE/esp-idf#v4.4-platformio
```

It still needs a updated idf framework package reference to the PlatformIO repository. 
https://registry.platformio.org/tools/platformio/framework-espidf/versions


