### PR TITLE
Add Lolin S2 Mini board

### DIFF
--- a/boards/lolin_s2_mini.json
+++ b/boards/lolin_s2_mini.json
@@ -1,0 +1,33 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s2_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_LOLIN_S2_MINI -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32s2",
+    "variant": "esp32s2"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "debug": {
+    "openocd_board": "esp32s2.cfg"
+  },
+  "frameworks": [
+    "espidf"
+  ],
+  "name": "WEMOS LOLIN S2 Mini",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.wemos.cc/en/latest/s2/s2_mini.html",
+  "vendor": "WEMOS"
+}

--- a/boards/lolin_s2_mini.json
+++ b/boards/lolin_s2_mini.json
@@ -1,15 +1,25 @@
 {
   "build": {
-    "arduino":{
+    "arduino": {
       "ldscript": "esp32s2_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_LOLIN_S2_MINI -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
+    "extra_flags": [
+      "-DARDUINO_LOLIN_S2_MINI",
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "dio",
+    "hwids": [
+      [
+        "0X303A",
+        "0x80C2"
+      ]
+    ],
     "mcu": "esp32s2",
-    "variant": "esp32s2"
+    "variant": "lolin_s2_mini"
   },
   "connectivity": [
     "wifi"
@@ -18,6 +28,7 @@
     "openocd_board": "esp32s2.cfg"
   },
   "frameworks": [
+    "arduino",
     "espidf"
   ],
   "name": "WEMOS LOLIN S2 Mini",
@@ -25,8 +36,10 @@
     "flash_size": "4MB",
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
     "require_upload_port": true,
-    "speed": 115200
+    "speed": 921600
   },
   "url": "https://www.wemos.cc/en/latest/s2/s2_mini.html",
   "vendor": "WEMOS"


### PR DESCRIPTION
Add Wemos/Lolin S2 Mini board (https://www.wemos.cc/en/latest/s2/s2_mini.html)

Has been tested with esphome using the following config:

```
esphome:
  name: testdev

esp32:
  board: lolin_s2_mini
  variant: ESP32S2
  framework:
    type: esp-idf
    platform_version: https://github.com/jhamhader/platform-espressif32#8bc085573e4f6986ffcda7050b9607739f3c6976

logger:

api:

wifi:
  ssid: "<ssid>"
  password: "<password>"
```

Important note:
For some reason, arm toolchain is broken (seems to be related to https://github.com/esphome/issues/issues/3076) and building failed on my Raspberry Pi. Building on my x86_64 Linux succeeded though.

Flashing succeeded using esphome generated command which included firmware, bootloader, and partitions:
(note that the command uses "/config/..." which refers is a directory mapped to the esphome container)
```
esptool.py --before default_reset --after hard_reset --baud 115200 --port /dev/ttyACM1 --chip esp32s2 write_flash -z --flash_size detect 0x10000 /config/.esphome/build/testdev/.pioenvs/testdev/firmware.bin 0x1000 /config/.esphome/build/testdev/.pioenvs/testdev/bootloader.bin 0x8000 /config/.esphome/build/testdev/.pioenvs/testdev/partitions.bin 0xd000 /config/.esphome/build/testdev/.pioenvs/testdev/ota_data_initial.bin
```
which was generated by esphome command:
```
docker run --rm -v ${HOME}/testdev/config:/config --device=/dev/ttyACM1:/dev/ttyACM1 -it esphome/esphome run testdev.yaml --device /dev/ttyACM1
```

Related to https://github.com/esphome/feature-requests/issues/1626