### PR TITLE
Add TTGO-T-Call to boards

### DIFF
--- a/boards/ttgo-t-call.json
+++ b/boards/ttgo-t-call.json
@@ -1,0 +1,35 @@
+{
+  "build": {
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_T_Call -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "ldscript": "esp32_out.ld",
+    "mcu": "esp32",
+    "variant": "t-call"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "can",
+    "ethernet"
+  ],
+  "debug": {
+    "openocd_board": "esp32-wrover.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "TTGO T-CALL",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 512000,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://github.com/Xinyuan-LilyGO/TTGO-T-Call",
+  "vendor": "TTGO"
+}


### PR DESCRIPTION
Add board definition for TTGO-T-Call, which is similar to TTGO-T-Beam.
Where are 4 variants of this board (https://github.com/Xinyuan-LilyGO/LilyGo-T-Call-SIM800). This proposed board definition was successfully tested with variant **SIM800L IP5306 20190610** (https://github.com/Xinyuan-LilyGO/LilyGo-T-Call-SIM800/blob/master/doc/SIM800L_IP5306.MD), but should work with the others also.