### PR TITLE
BPI runs at 240MHz

### DIFF
--- a/boards/bpi-bit.json
+++ b/boards/bpi-bit.json
@@ -5,7 +5,7 @@
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_BPI_BIT",
-    "f_cpu": "160000000L",
+    "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",
     "mcu": "esp32",


### PR DESCRIPTION
It looks like the BPI bit runs with a wroom-32 module which generally runs at 240MHz.
Also, the documentation mentions 240MHz several times: https://wiki.banana-pi.org/BPI-Bit