### PR TITLE
add airm2m core c3 board

### DIFF
--- a/boards/airm2m_core_c3.json
+++ b/boards/airm2m_core_c3.json
@@ -1,0 +1,37 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32c3_out.ld"
+    },
+    "core": "esp32",
+    "f_cpu": "160000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "extra_flags": [
+      "-DARDUINO_ESP32C3_DEV",
+      "-DAIRM2M_CORE_ESP32C3"
+    ],
+    "mcu": "esp32c3",
+    "variant": "AirM2M_CORE_ESP32C3"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32c3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "AirM2M CORE_ESP32C3",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 1152000
+  },
+  "url": "https://wiki.luatos.com/chips/esp32c3/board.html",
+  "vendor": "AirM2M"
+}

--- a/boards/airm2m_core_esp32c3.json
+++ b/boards/airm2m_core_esp32c3.json
@@ -8,8 +8,8 @@
     "f_flash": "80000000L",
     "flash_mode": "dio",
     "extra_flags": [
-      "-DARDUINO_ESP32C3_DEV",
-      "-DAIRM2M_CORE_ESP32C3"
+      "-DARDUINO_AirM2M_CORE_ESP32C3",
+      "-DARDUINO_USB_MODE=1"
     ],
     "mcu": "esp32c3",
     "variant": "AirM2M_CORE_ESP32C3"
@@ -24,13 +24,13 @@
     "arduino",
     "espidf"
   ],
-  "name": "AirM2M CORE_ESP32C3",
+  "name": "AirM2M CORE ESP32C3",
   "upload": {
     "flash_size": "4MB",
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 1152000
+    "speed": 460800
   },
   "url": "https://wiki.luatos.com/chips/esp32c3/board.html",
   "vendor": "AirM2M"


### PR DESCRIPTION
Added support for the AIRM2M CORE-ESP32C3 board, which has already had a great impact and has excellent sales on Taobao in China (https://item.taobao.com/item.htm?spm=a1z10.1-c-s.w4004-24090382179.12.1ec655d0ILdwls&id=666974425430)
Board introduction link(https://wiki.luatos.com/chips/esp32c3/board.html)
The arduino-esp32 repository already supports this board.
This pull request has been tested on CORE-ESP32C3.