### PR TITLE
Add support for Trueverit ESP32 Universal IoT Driver MK III

### DIFF
--- a/boards/trueverit-iot-driver-mk3.json
+++ b/boards/trueverit-iot-driver-mk3.json
@@ -35,3 +35,4 @@
   "url": "https://trueverit.com/",
   "vendor": "Trueverit"
 }
+

--- a/boards/trueverit-iot-driver-mk3.json
+++ b/boards/trueverit-iot-driver-mk3.json
@@ -1,0 +1,37 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_Trueverit_ESP32_Universal_IoT_Driver_MK_III",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "esp32-trueverit-iot-driver-mkiii"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Trueverit ESP32 Universal IoT Driver MK III",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://trueverit.com/",
+  "vendor": "Trueverit"
+}


### PR DESCRIPTION
@valeros, i've added the brand new Trueverit ESP32 Universal IoT Driver MK III, ESP32 based board with RTL8201 Lan PHY driver and PoE support.

Please, if it's everything okay accept my PR.