### PR TITLE
boards/um_feathers3: Don't flash tinyuf2.bin

### DIFF
--- a/boards/um_feathers3.json
+++ b/boards/um_feathers3.json
@@ -35,14 +35,6 @@
   ],
   "name": "Unexpected Maker FeatherS3",
   "upload": {
-    "arduino": {
-      "flash_extra_images": [
-        [
-          "0x410000",
-          "variants/um_feathers3/tinyuf2.bin"
-        ]
-      ]
-    },
     "flash_size": "16MB",
     "maximum_ram_size": 327680,
     "maximum_size": 16777216,


### PR DESCRIPTION
In Arduino IDE, tinyuf2.bin is only flashed when the tinyuf2 partition option is selected from the menu. Flashing the tinyuf2 binary without the appropriate partitions does not work and clobbers part of the app0 partition. cc @UnexpectedMaker 