### PR TITLE
Use empty ASM and CXX flags if config empty

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -394,20 +394,26 @@ def filter_args(args, allowed, ignore=None):
 def get_app_flags(app_config, default_config):
     def _extract_flags(config):
         flags = {}
-        for cg in config["compileGroups"]:
-            flags[cg["language"]] = []
-            for ccfragment in cg["compileCommandFragments"]:
-                fragment = ccfragment.get("fragment", "")
-                if not fragment.strip() or fragment.startswith("-D"):
-                    continue
-                flags[cg["language"]].extend(
-                    click.parser.split_arg_string(fragment.strip())
-                )
+        if "compileGroups" in config:
+            for cg in config["compileGroups"]:
+                flags[cg["language"]] = []
+                for ccfragment in cg["compileCommandFragments"]:
+                    fragment = ccfragment.get("fragment", "")
+                    if not fragment.strip() or fragment.startswith("-D"):
+                        continue
+                    flags[cg["language"]].extend(
+                        click.parser.split_arg_string(fragment.strip())
+                    )
 
         return flags
 
     app_flags = _extract_flags(app_config)
     default_flags = _extract_flags(default_config)
+    # No Flags? Add defaults
+    if "ASM" not in app_flags and "ASM" not in default_flags:
+        app_flags["ASM"] = []
+    if "CXX" not in app_flags and "CXX" not in default_flags:
+        app_flags["CXX"] = []
 
     # Flags are sorted because CMake randomly populates build flags in code model
     return {


### PR DESCRIPTION
Trying to compile the https://github.com/maxgerhardt/pio-espidf-aws-mqtt-ota project with `platform = https://github.com/platformio/platform-espressif32.git` that does not have this fix

```
PLATFORM: Espressif 32 (4.3.0+sha.b1b44fe) > Espressif ESP32 Dev Module
HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
PACKAGES:
 - framework-espidf @ 3.40302.0 (4.3.2)
 - tool-cmake @ 3.16.4
 - tool-esptoolpy @ 1.30300.0 (3.3.0)
 - tool-idf @ 1.0.1
 - tool-mconf @ 1.4060000.20190628 (406.0.0)
 - tool-ninja @ 1.9.0
 - toolchain-esp32ulp @ 1.22851.191205 (2.28.51)
 - toolchain-xtensa-esp32 @ 8.4.0+2021r2-patch3
WARNING: You are using pip version 21.1.3; however, version 22.1.1 is available.
You should consider upgrading via the 'c:\users\max\appdata\local\programs\python\python38\python.exe -m pip install --upgrade pip' command.
Reading CMake configuration...
KeyError: 'compileGroups':
  File "C:\Users\Max\appdata\local\programs\python\python38\lib\site-packages\platformio\builder\main.py", line 184:
    env.SConscript("$BUILD_SCRIPT")
  File "C:\Users\Max\.platformio\packages\tool-scons\scons-local-4.3.0\SCons\Script\SConscript.py", line 597:
    return _SConscript(self.fs, *files, **subst_kw)
  File "C:\Users\Max\.platformio\packages\tool-scons\scons-local-4.3.0\SCons\Script\SConscript.py", line 285:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "C:\Users\Max\.platformio\platforms\espressif32@src-5f117260f75b328038ec9d3fd0e14a68\builder\main.py", line 283:
    target_elf = env.BuildProgram()
  File "C:\Users\Max\.platformio\packages\tool-scons\scons-local-4.3.0\SCons\Util.py", line 742:
    return self.method(*nargs, **kwargs)
  File "C:\Users\Max\appdata\local\programs\python\python38\lib\site-packages\platformio\builder\tools\platformio.py", line 63:
    env.ProcessProgramDeps()
  File "C:\Users\Max\.platformio\packages\tool-scons\scons-local-4.3.0\SCons\Util.py", line 742:
    return self.method(*nargs, **kwargs)
  File "C:\Users\Max\appdata\local\programs\python\python38\lib\site-packages\platformio\builder\tools\platformio.py", line 126:
    env.BuildFrameworks(env.get("PIOFRAMEWORK"))
  File "C:\Users\Max\.platformio\packages\tool-scons\scons-local-4.3.0\SCons\Util.py", line 742:
    return self.method(*nargs, **kwargs)
  File "C:\Users\Max\appdata\local\programs\python\python38\lib\site-packages\platformio\builder\tools\platformio.py", line 340:
    SConscript(env.GetFrameworkScript(f), exports="env")
  File "C:\Users\Max\.platformio\packages\tool-scons\scons-local-4.3.0\SCons\Script\SConscript.py", line 660:
    return method(*args, **kw)
  File "C:\Users\Max\.platformio\packages\tool-scons\scons-local-4.3.0\SCons\Script\SConscript.py", line 597:
    return _SConscript(self.fs, *files, **subst_kw)
  File "C:\Users\Max\.platformio\packages\tool-scons\scons-local-4.3.0\SCons\Script\SConscript.py", line 285:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "C:\Users\Max\.platformio\platforms\espressif32@src-5f117260f75b328038ec9d3fd0e14a68\builder\frameworks\espidf.py", line 1276:
    project_flags = get_app_flags(project_config, default_config)
  File "C:\Users\Max\.platformio\platforms\espressif32@src-5f117260f75b328038ec9d3fd0e14a68\builder\frameworks\espidf.py", line 410:
    default_flags = _extract_flags(default_config)
  File "C:\Users\Max\.platformio\platforms\espressif32@src-5f117260f75b328038ec9d3fd0e14a68\builder\frameworks\espidf.py", line 397:
    for cg in config["compileGroups"]:
===================================================================================== [FAILED] Took 13.18 seconds =====================================================================================
```

When only executing the `for cg in config["compileGroups"]` loop if there is a compileGroups object, the state of `app_flags` and `default_flags` is 
```
{'C': ['-mlongcalls', '-Wno-frame-address', '-ffunction-sections', '-fdata-sections', '-Wall', '-Werror=all', '-Wno-error=unused-function', '-Wno-error=unused-variable', '-Wno-error=deprecated-declarations', '-Wextra', 
'-Wno-unused-parameter', '-Wno-sign-compare', '-ggdb', '-Og', '-fstrict-volatile-bitfields', '-Wno-error=unused-but-set-variable', '-std=gnu99', '-Wno-old-style-declaration']}
{}
```
so no ASM or CXX flags and there would be another execution with

```
TypeError: 'NoneType' object is not iterable:
[...]
  File "C:\Users\Max\.platformio\platforms\espressif32@src-5f117260f75b328038ec9d3fd0e14a68\builder\frameworks\espidf.py", line 1277:
    project_flags = get_app_flags(project_config, default_config)
  File "C:\Users\Max\.platformio\platforms\espressif32@src-5f117260f75b328038ec9d3fd0e14a68\builder\frameworks\espidf.py", line 417:
    "CXXFLAGS": sorted(app_flags.get("CXX", default_flags.get("CXX"))),
```

So I had to set empty defaults.

**With** both these two fixes applied, the firmware **builds** and uploads correctly, and executes fine.

