### PR TITLE
Add suport for Connaxio's Espoir

### DIFF
--- a/boards/connaxio_espoir.json
+++ b/boards/connaxio_espoir.json
@@ -1,0 +1,47 @@
+
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_CONNAXIO_ESPOIR",
+      "-DCONFIG_FREERTOS_UNICORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "connaxio_espoir",
+    "hwids": [
+      [
+        "0x10C4",
+        "0x8D9A"
+      ]
+    ]
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_board": "esp32-solo-1.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Connaxio's Espoir",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://www.connaxio.com/electronics/espoir/",
+  "vendor": "Connaxio"
+}


### PR DESCRIPTION
Adds the configuration file for Connaxio's Espoir devboard, a PoE+ mikroBUS<sup>TM</sup> mainboard based on the ESP32.

More info: https://www.connaxio.com/electronics/espoir/