### PR TITLE
Add hwids for OLIMEX ESP32 boards that use CH340 USB/serial converters

### DIFF
--- a/boards/esp32-devkitlipo.json
+++ b/boards/esp32-devkitlipo.json
@@ -8,6 +8,7 @@
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "qio",
+    "hwids": [["0x1A86", "0x7523"]],
     "mcu": "esp32",
     "variant": "esp32-devkit-lipo"
   },

--- a/boards/esp32-evb.json
+++ b/boards/esp32-evb.json
@@ -8,6 +8,7 @@
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",
+    "hwids": [["0x1A86", "0x7523"]],
     "mcu": "esp32",
     "variant": "esp32-evb"
   },

--- a/boards/esp32-gateway.json
+++ b/boards/esp32-gateway.json
@@ -8,6 +8,7 @@
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",
+    "hwids": [["0x1A86", "0x7523"]],
     "mcu": "esp32",
     "variant": "esp32-gateway"
   },

--- a/boards/esp32-poe-iso.json
+++ b/boards/esp32-poe-iso.json
@@ -8,6 +8,7 @@
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",
+    "hwids": [["0x1A86", "0x7523"]],
     "mcu": "esp32",
     "variant": "esp32-poe-iso"
   },

--- a/boards/esp32-poe.json
+++ b/boards/esp32-poe.json
@@ -8,6 +8,7 @@
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",
+    "hwids": [["0x1A86", "0x7523"]],
     "mcu": "esp32",
     "variant": "esp32-poe"
   },


### PR DESCRIPTION
I've verified in olimex's site that these boards all use the CH340 USB/serial converter, which has USB VID=1A86 PID=7523. While not unique (lots of devices use this converter), listing it is still helpful for distinguishing from other serial devices.

Note that the olimex ESP32-PRO does _not_ use this converter, instead it has a PIC32 used for USB, so it's not included in this change. (I don't have one, and I'm not sure what VID/PID it would end up with.)