### PR TITLE
Board definition adafruit_feather_esp32s3.json: change "flash_size" property to 8MB

### DIFF
--- a/boards/adafruit_feather_esp32s3.json
+++ b/boards/adafruit_feather_esp32s3.json
@@ -50,7 +50,7 @@
         ]
       ]
     },
-    "flash_size": "4MB",
+    "flash_size": "8MB",
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "use_1200bps_touch": true,

--- a/boards/adafruit_feather_esp32s3.json
+++ b/boards/adafruit_feather_esp32s3.json
@@ -52,7 +52,7 @@
     },
     "flash_size": "8MB",
     "maximum_ram_size": 327680,
-    "maximum_size": 4194304,
+    "maximum_size": 8388608,
     "use_1200bps_touch": true,
     "wait_for_upload_port": true,
     "require_upload_port": true,


### PR DESCRIPTION
This particular board has 8MB flash with no PSRAM. If the property is set to 4MB as in the current release version, platformio will throw an error while trying to flash any firmware to the board.

Setting flash_size to 8MB fixes the issue.