### PR TITLE
add Adafruit Feather ESP32-S3 TFT board

### DIFF
--- a/boards/adafruit_feather_esp32s3_tft.json
+++ b/boards/adafruit_feather_esp32s3_tft.json
@@ -1,25 +1,32 @@
 {
   "build": {
     "arduino": {
-      "ldscript": "esp32s3_out.ld"
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "partitions.csv"
     },
     "core": "esp32",
     "extra_flags": [
       "-DARDUINO_ADAFRUIT_FEATHER_ESP32S3_TFT",
-      "-DBOARD_HAS_PSRAM",
       "-DARDUINO_USB_CDC_ON_BOOT=1",
       "-DARDUINO_RUNNING_CORE=1",
       "-DARDUINO_EVENT_RUNNING_CORE=1"
     ],
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dio",
-    "boot": "qio",
+    "flash_mode": "qio",
     "hwids": [
-      ["0x239A", "0x811D"],
-      ["0x239A", "0x011D"],
-      ["0x239A", "0x811E"],
-      ["0x303A", "0x1001"]
+      [
+        "0x239A",
+        "0x811D"
+      ],
+      [
+        "0x239A",
+        "0x011D"
+      ],
+      [
+        "0x239A",
+        "0x811E"
+      ]
     ],
     "mcu": "esp32s3",
     "variant": "adafruit_feather_esp32s3_tft"

--- a/boards/adafruit_feather_esp32s3_tft.json
+++ b/boards/adafruit_feather_esp32s3_tft.json
@@ -18,7 +18,8 @@
     "hwids": [
       ["0x239A", "0x811D"],
       ["0x239A", "0x011D"],
-      ["0x239A", "0x811E"]
+      ["0x239A", "0x811E"],
+      ["0x303A", "0x1001"]
     ],
     "mcu": "esp32s3",
     "variant": "adafruit_feather_esp32s3_tft"

--- a/boards/adafruit_feather_esp32s3_tft.json
+++ b/boards/adafruit_feather_esp32s3_tft.json
@@ -1,0 +1,56 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ADAFRUIT_FEATHER_ESP32S3_TFT",
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "boot": "qio",
+    "hwids": [
+      ["0x239A", "0x811D"],
+      ["0x239A", "0x011D"],
+      ["0x239A", "0x811E"]
+    ],
+    "mcu": "esp32s3",
+    "variant": "adafruit_feather_esp32s3_tft"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Adafruit Feather ESP32-S3 TFT",
+  "upload": {
+    "arduino": {
+      "flash_extra_images": [
+        [
+          "0x2d0000",
+          "variants/adafruit_feather_esp32s3_tft/tinyuf2.bin"
+        ]
+      ]
+    },
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.adafruit.com/product/5483",
+  "vendor": "Adafruit"
+}


### PR DESCRIPTION
Product page: https://www.adafruit.com/product/5483
Arduino boards.txt entry: https://github.com/espressif/arduino-esp32/blob/c93bf11f1e3c3ca8088b837525dcdd78c8579a7a/boards.txt#L7984
Arduino variant definition: https://github.com/espressif/arduino-esp32/tree/master/variants/adafruit_feather_esp32s3_tft

Note this is a refresh of the Adafruit Feather ESP32-**S2** TFT board.