### PR TITLE
M5Stack misnamed as M5Stick

### DIFF
--- a/boards/m5stack-coreink.json
+++ b/boards/m5stack-coreink.json
@@ -21,7 +21,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "M5Stick-Core Ink",
+  "name": "M5Stack-Core Ink",
   "upload": {
     "flash_size": "4MB",
     "maximum_ram_size": 327680,


### PR DESCRIPTION
Fixed misnamed M5Stack, which was causing issues with documentation. See https://github.com/platformio/platformio-docs/pull/256#issuecomment-1180174467