### PR TITLE
Add board definitions for M5Station

### DIFF
--- a/boards/m5stack-station.json
+++ b/boards/m5stack-station.json
@@ -1,0 +1,34 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_M5Stack_Station",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "m5stack_station"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "M5Stack Station",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 4521984,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "http://www.m5stack.com",
+  "vendor": "M5Stack"
+}


### PR DESCRIPTION
The link to this development version is here.
[M5Station-485](https://docs.m5stack.com/en/core/station_485)
[M5Station-BAT](https://docs.m5stack.com/en/core/station_bat)