### PR TITLE
Add USB_CDC flag to Beetle ESP32-C3

### DIFF
--- a/boards/dfrobot_beetle_esp32c3.json
+++ b/boards/dfrobot_beetle_esp32c3.json
@@ -6,7 +6,8 @@
     "core": "esp32",
     "extra_flags": [
       "-DARDUINO_ESP32C3_DEV",
-      "-DARDUINO_USB_MODE=1"
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
     ],
     "f_cpu": "160000000L",
     "f_flash": "80000000L",


### PR DESCRIPTION
Adding "-DARDUINO_USB_CDC_ON_BOOT=1" to dfrobot_beetle_esp32c3.json, otherwise, the serial monitor from USB doesn't work.