### PR TITLE
set specific variant for lolin_c3_mini

### DIFF
--- a/boards/lolin_c3_mini.json
+++ b/boards/lolin_c3_mini.json
@@ -19,7 +19,7 @@
       ]
     ],
     "mcu": "esp32c3",
-    "variant": "esp32c3"
+    "variant": "lolin_c3_mini"
   },
   "connectivity": [
     "wifi"


### PR DESCRIPTION
I noticed that there is a specific variant for `lolin_c3_mini` but it is not used e.g. when compiling for the arduino framework. This caused e.g. `LED_BUILTIN` to resolve to the wrong pin number. This should fix it, I guess.