### PR TITLE
Fix flash mode for `opi`

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -51,10 +51,10 @@ def _get_board_f_flash(env):
 def _get_board_flash_mode(env):
     memory_type = env.BoardConfig().get("build.arduino.memory_type", "qio_qspi")
     mode = env.subst("$BOARD_FLASH_MODE")
-    if mode == "qio" or mode == "qout":
-        return "dio"
     if memory_type == "opi_opi" or memory_type == "opi_qspi":
         return "dout"
+    if mode == "qio" or mode == "qout":
+        return "dio"
     return mode
 
 

--- a/builder/main.py
+++ b/builder/main.py
@@ -49,10 +49,11 @@ def _get_board_f_flash(env):
 
 
 def _get_board_flash_mode(env):
+    memory_type = env.BoardConfig().get("build.arduino.memory_type", "qio_qspi")
     mode = env.subst("$BOARD_FLASH_MODE")
-    if mode == "qio":
+    if mode == "qio" or mode == "qout":
         return "dio"
-    elif mode == "qout":
+    if memory_type == "opi_opi" or memory_type == "opi_qspi":
         return "dout"
     return mode
 

--- a/builder/main.py
+++ b/builder/main.py
@@ -51,9 +51,9 @@ def _get_board_f_flash(env):
 def _get_board_flash_mode(env):
     memory_type = env.BoardConfig().get("build.arduino.memory_type", "qio_qspi")
     mode = env.subst("$BOARD_FLASH_MODE")
-    if memory_type == "opi_opi" or memory_type == "opi_qspi":
+    if memory_type in ("opi_opi", "opi_qspi"):
         return "dout"
-    if mode == "qio" or mode == "qout":
+    if mode in ("qio", "qout"):
         return "dio"
     return mode
 


### PR DESCRIPTION
opi needs to be flashed in mode `dout` to work. Changed flash mode for `qout` since it can be flashed in `dio`.
This is the way espressif now does in IDF
Related https://github.com/platformio/platform-espressif32/issues/837#issuecomment-1236378086