### PR TITLE
Use correct bootloader `opi` when `"boot": "opi"` is not set

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -59,9 +59,9 @@ def _get_board_flash_mode(env):
 
 
 def _get_board_boot_mode(env):
-    memory_type = env.BoardConfig().get("build.arduino.memory_type")
+    memory_type = env.BoardConfig().get("build.arduino.memory_type", "")
     build_boot = env.BoardConfig().get("build.boot", "$BOARD_FLASH_MODE")
-    if memory_type in ("opi_opi", "opi_qspi"):
+    if ["arduino"] == env.get("PIOFRAMEWORK") and memory_type in ("opi_opi", "opi_qspi"):
         build_boot = "opi"
     return build_boot
 

--- a/builder/main.py
+++ b/builder/main.py
@@ -49,7 +49,7 @@ def _get_board_f_flash(env):
 
 
 def _get_board_flash_mode(env):
-    memory_type = env.BoardConfig().get("build.arduino.memory_type")
+    memory_type = env.BoardConfig().get("build.arduino.memory_type", "qio_qspi")
     mode = env.subst("$BOARD_FLASH_MODE")
     if memory_type in ("opi_opi", "opi_qspi"):
         return "dout"
@@ -59,7 +59,7 @@ def _get_board_flash_mode(env):
 
 
 def _get_board_boot_mode(env):
-    memory_type = env.BoardConfig().get("build.arduino.memory_type", "qio_qspi")
+    memory_type = env.BoardConfig().get("build.arduino.memory_type")
     build_boot = env.BoardConfig().get("build.boot", "$BOARD_FLASH_MODE")
     if memory_type in ("opi_opi", "opi_qspi"):
         build_boot = "opi"

--- a/builder/main.py
+++ b/builder/main.py
@@ -59,7 +59,11 @@ def _get_board_flash_mode(env):
 
 
 def _get_board_boot_mode(env):
-    return env.BoardConfig().get("build.boot", "$BOARD_FLASH_MODE")
+    memory_type = env.BoardConfig().get("build.arduino.memory_type", "qio_qspi")
+    build_boot = env.BoardConfig().get("build.boot", "$BOARD_FLASH_MODE")
+    if memory_type in ("opi_opi", "opi_qspi"):
+        build_boot = "opi"
+    return build_boot
 
 
 def _parse_size(value):

--- a/builder/main.py
+++ b/builder/main.py
@@ -49,7 +49,7 @@ def _get_board_f_flash(env):
 
 
 def _get_board_flash_mode(env):
-    memory_type = env.BoardConfig().get("build.arduino.memory_type", "qio_qspi")
+    memory_type = env.BoardConfig().get("build.arduino.memory_type")
     mode = env.subst("$BOARD_FLASH_MODE")
     if memory_type in ("opi_opi", "opi_qspi"):
         return "dout"


### PR DESCRIPTION
for ESP32-S3 devices with flash type `opi`.  This prevents errors in compile since platformio searches for the bootloader `bootloader_dout_80m.bin` which does not exists and would be wrong.
With the change the correct bootloader `bootloader_opi_80m.bin` is used.

@chegewara thx for pointing at and this PR [fixes](https://github.com/platformio/platform-espressif32/issues/837#issuecomment-1246382561) this issue.

@valeros enhances #904 since it is more user friendly. It is hard to know to set all needed options correctly.
This is now done automatically
