### PR TITLE
fix "memory_type" for esp32s3box

### DIFF
--- a/boards/esp32s3box.json
+++ b/boards/esp32s3box.json
@@ -2,12 +2,10 @@
   "build": {
     "arduino":{
       "ldscript": "esp32s3_out.ld",
-      "memory_type": "qspi_opi"
+      "memory_type": "qio_opi"
     },
     "core": "esp32",
     "extra_flags": [
-      "-DARDUINO_RUNNING_CORE=1",
-      "-DARDUINO_EVENT_RUNNING_CORE=1",
       "-DBOARD_HAS_PSRAM",
       "-DARDUINO_ESP32_S3_BOX",
       "-DARDUINO_USB_MODE=1",


### PR DESCRIPTION
since the naming changed. Fixes #912
Remove not needed entrys