### PR TITLE
Sort ULP Sources

### DIFF
--- a/builder/frameworks/ulp.py
+++ b/builder/frameworks/ulp.py
@@ -83,6 +83,7 @@ def generate_ulp_config(target_config):
     riscv_ulp_enabled = sdk_config.get("ESP32S2_ULP_COPROC_RISCV", False)
 
     ulp_sources = collect_ulp_sources()
+    ulp_sources.sort()
     cmd = (
         os.path.join(platform.get_package_dir("tool-cmake"), "bin", "cmake"),
         "-DCMAKE_GENERATOR=Ninja",


### PR DESCRIPTION
os.listdir returns files in arbitrary order. This can cause relocation errors if files are listed in the "wrong" order.
This sorting allows the user to influence the order via the filenames.