### PR TITLE
--dont-append-digest

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -261,6 +261,7 @@ env.Append(
             action=env.VerboseAction(" ".join([
                 '"$PYTHONEXE" "$OBJCOPY"',
                 "--chip", mcu, "elf2image",
+                "--dont-append-digest",
                 "--flash_mode", "$BOARD_FLASH_MODE",
                 "--flash_freq", "${__get_board_f_flash(__env__)}",
                 "--flash_size", board.get("upload.flash_size", "4MB"),


### PR DESCRIPTION
safeguard to make sure esptool.py v4.4 can patch magic bytes. Since esptool v4.x does check for existing sha diggest and if existing does no header patching