### PR TITLE
Fix ULP RISCV compile with IDF5

### DIFF
--- a/builder/frameworks/ulp.py
+++ b/builder/frameworks/ulp.py
@@ -77,7 +77,7 @@ def get_component_includes(target_config):
 
 
 def generate_ulp_config(target_config):
-    riscv_ulp_enabled = sdk_config.get("ESP32S2_ULP_COPROC_RISCV", False)
+    riscv_ulp_enabled = sdk_config.get("ULP_COPROC_TYPE_RISCV", False)
 
     ulp_sources = collect_ulp_sources()
     cmd = (
@@ -89,8 +89,8 @@ def generate_ulp_config(target_config):
             "components",
             "ulp",
             "cmake",
-            "toolchain-%s-ulp%s.cmake"
-            % (idf_variant, "-riscv" if riscv_ulp_enabled else ""),
+            "toolchain-%sulp%s.cmake"
+            % ("" if riscv_ulp_enabled else idf_variant + "-", "-riscv" if riscv_ulp_enabled else ""),
         ),
         '-DULP_S_SOURCES="%s"' % ";".join(ulp_sources),
         "-DULP_APP_NAME=ulp_main",


### PR DESCRIPTION
now the enabled RISCV ULP is not detected. So wrong FSM ULP setup is done.

@valeros 