### PR TITLE
Add board definitions for M5AtomS3

### DIFF
--- a/boards/m5stack-atoms3
+++ b/boards/m5stack-atoms3
@@ -1,0 +1,50 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_8MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_M5STACK_S3_DEV",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "m5stack_atoms3"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "M5Stack AtomS3",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://docs.m5stack.com/en/core/AtomS3",
+  "vendor": "M5Stack"
+}

--- a/boards/m5stack-atoms3
+++ b/boards/m5stack-atoms3
@@ -1,12 +1,12 @@
 {
   "build": {
-    "arduino":{
+    "arduino": {
       "ldscript": "esp32s3_out.ld",
       "partitions": "default_8MB.csv"
     },
     "core": "esp32",
     "extra_flags": [
-      "-DARDUINO_M5STACK_S3_DEV",
+      "-DARDUINO_M5Stack_ATOMS3",
       "-DARDUINO_USB_MODE=1",
       "-DARDUINO_RUNNING_CORE=1",
       "-DARDUINO_EVENT_RUNNING_CORE=1"
@@ -27,10 +27,6 @@
     "wifi"
   ],
   "debug": {
-    "default_tool": "esp-builtin",
-    "onboard_tools": [
-      "esp-builtin"
-    ],
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [


### PR DESCRIPTION
Hi @valeros, Please help review this board.

The relevant link for this development version is here. 

Variant files about `M5AtomS3` https://github.com/espressif/arduino-esp32/blob/master/variants/m5stack_atoms3/pins_arduino.h

