### PR TITLE
Fix compile issue on new environments

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1078,7 +1078,7 @@ def install_python_deps():
         # https://github.com/platformio/platform-espressif32/issues/635
         "cryptography": ">=2.1.4,<35.0.0",
         "future": ">=0.15.2",
-        "pyparsing": ">=2.0.3,<2.4.0",
+        "pyparsing": ">=3.0.9",
         "kconfiglib": "==13.7.1",
         "idf-component-manager": "~=1.0",
     }


### PR DESCRIPTION
This PR fixes a dependency version for pyparsing needed for compiling ESP32.

There are some reports of this and the fix was being done manually:
* https://www.esp32.com/viewtopic.php?f=13&p=108741
* https://github.com/platformio/platform-espressif32/issues/1007
* https://github.com/platformio/platform-espressif32/issues/979