### PR TITLE
Allow uppercase registers in exception decoder

### DIFF
--- a/monitor/filter_exception_decoder.py
+++ b/monitor/filter_exception_decoder.py
@@ -33,7 +33,7 @@ class Esp32ExceptionDecoder(DeviceMonitorFilterBase):
     NAME = "esp32_exception_decoder"
 
     BACKTRACE_PATTERN = re.compile(r"^Backtrace:(((\s?0x[0-9a-fA-F]{8}:0x[0-9a-fA-F]{8}))+)")
-    BACKTRACE_ADDRESS_PATTERN = re.compile(r'0x[0-9a-f]{8}:0x[0-9a-f]{8}')
+    BACKTRACE_ADDRESS_PATTERN = re.compile(r'0x[0-9a-fA-F]{8}:0x[0-9a-fA-F]{8}')
 
     def __call__(self):
         self.buffer = ""


### PR DESCRIPTION
It now also successfully handles backtraces where the register has upper case letters, where it wouldn't process them before (see #1019 for details):

```
E (26372) task_wdt: Task watchdog got triggered. The following tasks/users did not reset the watchdog in time:
E (26372) task_wdt:  - IDLE (CPU 1)
E (26372) task_wdt: Tasks currently running:
E (26372) task_wdt: CPU 0: IDLE
E (26372) task_wdt: CPU 1: pthread
E (26372) task_wdt: Print CPU 1 backtrace


Backtrace: 0x4037877E:0x3FC92FB0 0x403766EA:0x3FC92FD0 0x4037A5F6:0x3FCEADC0 0x40377190:0x3FCEAE00 0x42003551:0x3FCEAE20 0x4204E2CD:0x3FCEAE80 0x42026C0D:0x3FCEAEA0 0x42010768:0x3FCEAED0 0x4037CDB9:0x3FCEAEF0

  #0  0x4037877E:0x3FC92FB0 in esp_crosscore_isr at C:\Users\Daan\.platformio\packages\framework-espidf\components\esp_system/crosscore_int.c:96
  #1  0x403766EA:0x3FC92FD0 in _xt_lowint1 at C:\Users\Daan\.platformio\packages\framework-espidf\components\freertos\FreeRTOS-Kernel\portable\xtensa/xtensa_vectors.S:1117
  #2  0x4037A5F6:0x3FCEADC0 in xQueueGenericSend at C:\Users\Daan\.platformio\packages\framework-espidf\components\freertos\FreeRTOS-Kernel/queue.c:828 (discriminator 2)
  #3  0x40377190:0x3FCEAE00 in pthread_mutex_unlock at C:\Users\Daan\.platformio\packages\framework-espidf\components\pthread/pthread.c:700
  #4  0x42003551:0x3FCEAE20 in CANHardwareInterface::can_thread_function() at c:\users\daan\.platformio\packages\toolchain-xtensa-esp32s3\xtensa-esp32s3-elf\include\c++\11.2.0\xtensa-esp32s3-elf\no-rtti\bits/gthr-default.h:779 (discriminator 2)
      (inlined by) std::mutex::unlock() at c:\users\daan\.platformio\packages\toolchain-xtensa-esp32s3\xtensa-esp32s3-elf\include\c++\11.2.0\bits/std_mutex.h:118 (discriminator 2)
      (inlined by) CANHardwareInterface::can_thread_function() at lib/isobus/hardware_integration/src/can_hardware_interface.cpp:455 (discriminator 2)
  #5  0x4204E2CD:0x3FCEAE80 in void std::__invoke_impl<void, void (*)()>(std::__invoke_other, void (*&&)()) at c:\users\daan\.platformio\packages\toolchain-xtensa-esp32s3\xtensa-esp32s3-elf\include\c++\11.2.0\bits/invoke.h:61
      (inlined by) std::__invoke_result<void (*)()>::type std::__invoke<void (*)()>(void (*&&)()) at c:\users\daan\.platformio\packages\toolchain-xtensa-esp32s3\xtensa-esp32s3-elf\include\c++\11.2.0\bits/invoke.h:96
      (inlined by) void std::thread::_Invoker<std::tuple<void (*)()> >::_M_invoke<0u>(std::_Index_tuple<0u>) at c:\users\daan\.platformio\packages\toolchain-xtensa-esp32s3\xtensa-esp32s3-elf\include\c++\11.2.0\bits/std_thread.h:253
      (inlined by) std::thread::_Invoker<std::tuple<void (*)()> >::operator()() at c:\users\daan\.platformio\packages\toolchain-xtensa-esp32s3\xtensa-esp32s3-elf\include\c++\11.2.0\bits/std_thread.h:260
      (inlined by) std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)()> > >::_M_run() at c:\users\daan\.platformio\packages\toolchain-xtensa-esp32s3\xtensa-esp32s3-elf\include\c++\11.2.0\bits/std_thread.h:211
  #6  0x42026C0D:0x3FCEAEA0 in execute_native_thread_routine at thread.cc:?
  #7  0x42010768:0x3FCEAED0 in pthread_task_func at C:\Users\Daan\.platformio\packages\framework-espidf\components\pthread/pthread.c:196 (discriminator 15)
  #8  0x4037CDB9:0x3FCEAEF0 in vPortTaskWrapper at C:\Users\Daan\.platformio\packages\framework-espidf\components\freertos\FreeRTOS-Kernel\portable\xtensa/port.c:151
```

Closes #1019 