### PR TITLE
add support for DFRobot FireBeetle 2 ESP32-E board

### DIFF
--- a/boards/dfrobot_firebeetle2_esp32e.json
+++ b/boards/dfrobot_firebeetle2_esp32e.json
@@ -29,7 +29,7 @@
   "name": "DFRobot Firebeetle 2 ESP32-E",
   "upload": {
     "flash_size": "4MB",
-    "maximum_ram_size": 532480,
+    "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
     "speed": 460800

--- a/boards/dfrobot_firebeetle2_esp32e.json
+++ b/boards/dfrobot_firebeetle2_esp32e.json
@@ -1,10 +1,14 @@
 {
   "build": {
-    "arduino":{
+    "arduino": {
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_ESP32_DEV",
+    "extra_flags": [
+      "-DARDUINO_DFROBOT_FIREBEETLE_2_ESP32E",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",

--- a/boards/dfrobot_firebeetle2_esp32e.json
+++ b/boards/dfrobot_firebeetle2_esp32e.json
@@ -1,0 +1,35 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_ESP32_DEV",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "dfrobot_firebeetle2_esp32e"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "DFRobot Firebeetle 2 ESP32-E",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 532480,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://wiki.dfrobot.com/FireBeetle_Board_ESP32_E_SKU_DFR0654",
+  "vendor": "DFRobot"
+}


### PR DESCRIPTION
This PR adds support for the DFRobot FireBeetle 2 ESP32-E board.

This will close the following issues

- https://github.com/platformio/platform-espressif32/issues/644
- https://github.com/platformio/platform-espressif32/issues/1002

Related PR to add DFRobot FireBeetle 2 ESP32-E board support to arduino-esp32: https://github.com/espressif/arduino-esp32/pull/7835