### PR TITLE
ADD: heltec wsl v3 board variant support

### DIFF
--- a/boards/heltec_wireless_stick_lite_v3.json
+++ b/boards/heltec_wireless_stick_lite_v3.json
@@ -1,0 +1,34 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_HELTEC_WIRELESS_STICK_LITE",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32s3",
+    "variant": "heltec_wireless_stick_lite_v3"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Heltec Wireless Stick Lite (V3)",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://heltec.org/project/wireless-stick-lite-v2/",
+  "vendor": "Heltec Automation"
+}


### PR DESCRIPTION
Added the json file for board compatibility with the Heltec Wireless Stick Lite V3 (updated chip to esp32s3).