### PR TITLE
Fix Seeed XIAO ESP32S3 PSRAM

### DIFF
--- a/boards/seeed_xiao_esp32s3.json
+++ b/boards/seeed_xiao_esp32s3.json
@@ -3,7 +3,7 @@
     "arduino": {
       "ldscript": "esp32s3_out.ld",
       "partitions": "default_8MB.csv",
-      "memory_type": "qio_qspi"
+      "memory_type": "qio_opi"
     },
     "core": "esp32",
     "extra_flags": [


### PR DESCRIPTION
I tried running a code that uses the PSRAM, but I got the following error:

```
E (164) psram: PSRAM ID read error: 0x00ffffff
```

I changed the `memory_type` of the seeed_xiao_esp32s3.json definition file to `qio_opi` and then the PSRAM issue is fixed.

This PR intends to fix this problem.