### PR TITLE
S3 Eye has 8MB OPI Flash

### DIFF
--- a/boards/esp32s3camlcd.json
+++ b/boards/esp32s3camlcd.json
@@ -38,9 +38,9 @@
   ],
   "name": "ESP32S3 CAM LCD",
   "upload": {
-    "flash_size": "4MB",
+    "flash_size": "8MB",
     "maximum_ram_size": 327680,
-    "maximum_size": 16777216,
+    "maximum_size": 8388608,
     "require_upload_port": true,
     "speed": 921600
   },


### PR DESCRIPTION
as documented here https://www.espressif.com/en/news/Maple_Eye_ESP32-S3 fixes https://github.com/platformio/platform-espressif32/issues/1095