### PR TITLE
Fix OpenOCD board -> target on Lolin S2 Mini

### DIFF
--- a/boards/lolin_s2_mini.json
+++ b/boards/lolin_s2_mini.json
@@ -25,7 +25,7 @@
     "wifi"
   ],
   "debug": {
-    "openocd_board": "esp32s2.cfg"
+    "openocd_target": "esp32s2.cfg"
   },
   "frameworks": [
     "arduino",

--- a/boards/lolin_s2_pico.json
+++ b/boards/lolin_s2_pico.json
@@ -25,7 +25,7 @@
     "wifi"
   ],
   "debug": {
-    "openocd_board": "esp32s2.cfg"
+    "openocd_target": "esp32s2.cfg"
   },
   "frameworks": [
     "arduino",


### PR DESCRIPTION
There is no `board/esp32s2.cfg`. But there is `target/esp32s2.cfg`.

Reported per [community forum](https://community.platformio.org/t/error-cant-find-board-esp32s2-cfg-in-procedure-script/34544).