### PR TITLE
Add Adafruit QT PY S3 with 4MB flash 2 MB PSRAM

### DIFF
--- a/boards/adafruit_qtpy_esp32s3_n4r2.json
+++ b/boards/adafruit_qtpy_esp32s3_n4r2.json
@@ -1,0 +1,49 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "partitions-4MB-tinyuf2.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ADAFRUIT_QTPY_ESP32S3_N4R2",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x239A",
+        "0x8143"
+      ],
+    ],
+    "mcu": "esp32s3",
+    "variant": "adafruit_qtpy_esp32s3_n4r2"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Adafruit QT Py ESP32-S3 (4M Flash, 2M PSRAM)",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.adafruit.com/product/5700",
+  "vendor": "Adafruit"
+}

--- a/boards/adafruit_qtpy_esp32s3_n4r2.json
+++ b/boards/adafruit_qtpy_esp32s3_n4r2.json
@@ -20,6 +20,10 @@
         "0x239A",
         "0x8143"
       ],
+      [
+        "0x303A",
+        "0x1001"
+      ]
     ],
     "mcu": "esp32s3",
     "variant": "adafruit_qtpy_esp32s3_n4r2"


### PR DESCRIPTION
Please add support for this board: https://www.adafruit.com/product/5700 .
The _nopsram variant does not work because it requires 8MB flash_size but this board has only 4mb flash + 2mb psram.
I tested it with a blink sketch.