### PR TITLE
Add OpenOCD support for onboard ESP32-S2-Kaluga-1 debug tool

### DIFF
--- a/boards/esp32-s2-kaluga-1.json
+++ b/boards/esp32-s2-kaluga-1.json
@@ -18,7 +18,7 @@
     "onboard_tools": [
       "ftdi"
     ],
-    "openocd_target": "esp32s2.cfg"
+    "openocd_board": "esp32s2-kaluga-1.cfg"
   },
   "frameworks": [
     "arduino",

--- a/boards/esp32-s2-kaluga-1.json
+++ b/boards/esp32-s2-kaluga-1.json
@@ -29,6 +29,11 @@
     "flash_size": "4MB",
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
+    "protocols": [
+      "esptool",
+      "espota",
+      "ftdi"
+    ],    
     "require_upload_port": true,
     "speed": 460800
   },

--- a/platform.json
+++ b/platform.json
@@ -114,7 +114,7 @@
       "type": "debugger",
       "optional": true,
       "owner": "platformio",
-      "version": "~2.1100.0"
+      "version": "~2.1200.0"
     },
     "tool-mkspiffs": {
       "type": "uploader",


### PR DESCRIPTION
This PR updates the default OpenOCD version from v0.11 to v0.12 (which adds support for the Kaluga dev board amongst other things) and changes the board definition to refer to the Espressif-provided configuration file.

I've tested this with a Kaluga board locally and can confirm that - although requiring a bit of driver-juggling, similar to other Espressif dev boards - it works. 