### PR TITLE
added new boards namino rosso / arancio

### DIFF
--- a/boards/namino_arancio.json
+++ b/boards/namino_arancio.json
@@ -6,7 +6,6 @@
       },
       "core": "esp32",
       "extra_flags": [
-        "-DBOARD_HAS_PSRAM",
         "-DARDUINO_NAMINO_ARANCIO",
         "-DARDUINO_USB_MODE=1"
       ],

--- a/boards/namino_arancio.json
+++ b/boards/namino_arancio.json
@@ -1,46 +1,46 @@
 {
-    "build": {
-      "arduino": {
-        "ldscript": "esp32s3_out.ld",
-        "memory_type": "qio_qspi"
-      },
-      "core": "esp32",
-      "extra_flags": [
-        "-DARDUINO_NAMINO_ARANCIO",
-        "-DARDUINO_USB_MODE=1"
-      ],
-      "f_cpu": "240000000L",
-      "f_flash": "80000000L",
-      "flash_mode": "qio",
-      "hwids": [
-        [
-          "0x303A",
-          "0x1001"
-        ]
-      ],
-      "mcu": "esp32s3",
-      "variant": "namino_arancio"
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_qspi"
     },
-    "connectivity": [
-      "wifi"
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_NAMINO_ARANCIO",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
     ],
-    "debug": {
-      "openocd_target": "esp32s3.cfg"
-    },
-    "frameworks": [
-      "arduino",
-      "espidf"
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
     ],
-    "name": "NAMINO ARANCIO",
-    "upload": {
-      "flash_size": "4MB",
-      "maximum_ram_size": 327680,
-      "maximum_size": 4194304,
-      "use_1200bps_touch": true,
-      "require_upload_port": true,
-      "speed": 460800
-    },
-    "url": "https://namino.cc/boards/namino-arancio",
-    "vendor": "MECT SRL"
+    "mcu": "esp32s3",
+    "variant": "namino_arancio"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Namino Arancio",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://namino.cc/boards/namino-arancio",
+  "vendor": "MECT SRL"
 }
-  

--- a/boards/namino_arancio.json
+++ b/boards/namino_arancio.json
@@ -36,6 +36,7 @@
       "flash_size": "4MB",
       "maximum_ram_size": 327680,
       "maximum_size": 4194304,
+      "use_1200bps_touch": true,
       "require_upload_port": true,
       "speed": 460800
     },

--- a/boards/namino_arancio.json
+++ b/boards/namino_arancio.json
@@ -1,0 +1,46 @@
+{
+    "build": {
+      "arduino": {
+        "ldscript": "esp32s3_out.ld",
+        "memory_type": "qio_qspi"
+      },
+      "core": "esp32",
+      "extra_flags": [
+        "-DBOARD_HAS_PSRAM",
+        "-DARDUINO_NAMINO_ARANCIO",
+        "-DARDUINO_USB_MODE=1"
+      ],
+      "f_cpu": "240000000L",
+      "f_flash": "80000000L",
+      "flash_mode": "qio",
+      "hwids": [
+        [
+          "0x303A",
+          "0x1001"
+        ]
+      ],
+      "mcu": "esp32s3",
+      "variant": "namino_arancio"
+    },
+    "connectivity": [
+      "wifi"
+    ],
+    "debug": {
+      "openocd_target": "esp32s3.cfg"
+    },
+    "frameworks": [
+      "arduino",
+      "espidf"
+    ],
+    "name": "NAMINO ARANCIO",
+    "upload": {
+      "flash_size": "4MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 4194304,
+      "require_upload_port": true,
+      "speed": 460800
+    },
+    "url": "https://namino.cc/boards/namino-arancio",
+    "vendor": "MECT SRL"
+}
+  

--- a/boards/namino_rosso.json
+++ b/boards/namino_rosso.json
@@ -1,0 +1,46 @@
+{
+    "build": {
+      "arduino": {
+        "ldscript": "esp32s3_out.ld",
+        "memory_type": "qio_qspi"
+      },
+      "core": "esp32",
+      "extra_flags": [
+        "-DBOARD_HAS_PSRAM",
+        "-DARDUINO_NAMINO_ROSSO",
+        "-DARDUINO_USB_MODE=1"
+      ],
+      "f_cpu": "240000000L",
+      "f_flash": "80000000L",
+      "flash_mode": "qio",
+      "hwids": [
+        [
+          "0x303A",
+          "0x1001"
+        ]
+      ],
+      "mcu": "esp32s3",
+      "variant": "namino_rosso"
+    },
+    "connectivity": [
+      "wifi"
+    ],
+    "debug": {
+      "openocd_target": "esp32s3.cfg"
+    },
+    "frameworks": [
+      "arduino",
+      "espidf"
+    ],
+    "name": "NAMINO ROSSO",
+    "upload": {
+      "flash_size": "4MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 4194304,
+      "require_upload_port": true,
+      "speed": 460800
+    },
+    "url": "https://namino.cc/boards/namino-rosso",
+    "vendor": "MECT SRL"
+}
+  

--- a/boards/namino_rosso.json
+++ b/boards/namino_rosso.json
@@ -6,7 +6,6 @@
       },
       "core": "esp32",
       "extra_flags": [
-        "-DBOARD_HAS_PSRAM",
         "-DARDUINO_NAMINO_ROSSO",
         "-DARDUINO_USB_MODE=1"
       ],

--- a/boards/namino_rosso.json
+++ b/boards/namino_rosso.json
@@ -1,46 +1,46 @@
 {
-    "build": {
-      "arduino": {
-        "ldscript": "esp32s3_out.ld",
-        "memory_type": "qio_qspi"
-      },
-      "core": "esp32",
-      "extra_flags": [
-        "-DARDUINO_NAMINO_ROSSO",
-        "-DARDUINO_USB_MODE=1"
-      ],
-      "f_cpu": "240000000L",
-      "f_flash": "80000000L",
-      "flash_mode": "qio",
-      "hwids": [
-        [
-          "0x303A",
-          "0x1001"
-        ]
-      ],
-      "mcu": "esp32s3",
-      "variant": "namino_rosso"
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_qspi"
     },
-    "connectivity": [
-      "wifi"
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_NAMINO_ROSSO",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
     ],
-    "debug": {
-      "openocd_target": "esp32s3.cfg"
-    },
-    "frameworks": [
-      "arduino",
-      "espidf"
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
     ],
-    "name": "NAMINO ROSSO",
-    "upload": {
-      "flash_size": "4MB",
-      "maximum_ram_size": 327680,
-      "maximum_size": 4194304,
-      "use_1200bps_touch": true,
-      "require_upload_port": true,
-      "speed": 460800
-    },
-    "url": "https://namino.cc/boards/namino-rosso",
-    "vendor": "MECT SRL"
+    "mcu": "esp32s3",
+    "variant": "namino_rosso"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Namino Rosso",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://namino.cc/boards/namino-rosso",
+  "vendor": "MECT SRL"
 }
-  

--- a/boards/namino_rosso.json
+++ b/boards/namino_rosso.json
@@ -36,6 +36,7 @@
       "flash_size": "4MB",
       "maximum_ram_size": 327680,
       "maximum_size": 4194304,
+      "use_1200bps_touch": true,
       "require_upload_port": true,
       "speed": 460800
     },


### PR DESCRIPTION
Namino Boards: Namino combines the industrial world with the world of makers by making digital analog inputs, outputs and compatible Arduino shields available on the same board.

CPU: ESP32-S3-WROOM-1U-N4R8

```
NAMINO ROSSO provides the following input/output lines:
8 PNP digital inputs (up to 24Vdc)
1 knob input and button
8 PNP digital outputs (up to 24Vdc) of which 1 for stepper motor command with total current 200mA
1 SPDT relay output of 5A
8 single ended analog inputs (0-10V or 0-20mA) or 4 thermometric (NTC, PTC, PT1000) or 4 thermocouples (J, K, T) or 2 load cells, software configurable
1 analog output jumper configurable: 0-10V or 0-20mA
ARDUINO UNO compatible shield interface 


NAMINO ARANCIO provides the following input/output lines:
8 PNP digital inputs (up to 24Vdc)
1 knob input and button
8 PNP digital outputs (up to 24Vdc) of which 1 for stepper motor command with total current 200mA
1 SPDT relay output of 5A
4 analog inputs (0-10V or 0-20mA) software configurable
1 input for NTC (10kΩ) or board temperature reading
1 analog output jumper configurable: 0-10V or 0-20mA
ARDUINO UNO compatible shield interface 
```