### PR TITLE
Update lolin_s3.json

### DIFF
--- a/boards/lolin_s3.json
+++ b/boards/lolin_s3.json
@@ -15,6 +15,7 @@
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "qio",
+    "psram_type": "opi",
     "hwids": [
       [
         "0x303A",
@@ -25,7 +26,8 @@
     "variant": "lolin_s3"
   },
   "connectivity": [
-    "wifi"
+    "wifi",
+    "bluetooth"
   ],
   "debug": {
     "openocd_target": "esp32s3.cfg"

--- a/boards/lolin_s3.json
+++ b/boards/lolin_s3.json
@@ -15,7 +15,6 @@
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "qio",
-    "psram_type": "opi",
     "hwids": [
       [
         "0x303A",


### PR DESCRIPTION
Board was missing BT connectivity. 
PSRAM type is octal SPI => opi.

https://www.wemos.cc/en/latest/s3/s3.html