### PR TITLE
Added bee data logger board

### DIFF
--- a/boards/bee_data_logger.json
+++ b/boards/bee_data_logger.json
@@ -1,0 +1,48 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_BeeDataLogger",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x815C"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "Bee_Data_Logger"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Smart Bee Data Logger",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://github.com/strid3r21/Bee-Data-Logger",
+  "vendor": "Smart Bee"
+}


### PR DESCRIPTION
hope im doing this right. adding one of my boards for my company Smart Bee. 

my other boards have already been added by someone else at some point, but this particular board is not available in the platformIO IDE yet so im adding it here. (hopefully this is the correct repo to add to so that this option appears in the platformIO IDE.)

