### PR TITLE
Update old uPesy boards info & Add new uPesy boards

### DIFF
--- a/boards/upesy_edu_esp32.json
+++ b/boards/upesy_edu_esp32.json
@@ -1,0 +1,37 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_uPesy_edu_esp32",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "mcu": "esp32",
+    "variant": "uPesy_edu_esp32"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "uPesy EDU ESP32",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.upesy.com/products/esp32-arduino-uno-format",
+  "vendor": "uPesy"
+}

--- a/boards/upesy_esp32c3_basic.json
+++ b/boards/upesy_esp32c3_basic.json
@@ -1,0 +1,44 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32c3_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_UPESY_ESP32C3_BASIC",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
+    "f_cpu": "160000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0X303A",
+        "0x8195"
+      ]
+    ],
+    "mcu": "esp32c3",
+    "variant": "uPesy_esp32c3_mini"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32c3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "uPesy ESP32C3 Basic",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.upesy.com/products/esp32c3-low-power-basic-board",
+  "vendor": "uPesy"
+}

--- a/boards/upesy_esp32c3_mini.json
+++ b/boards/upesy_esp32c3_mini.json
@@ -1,0 +1,44 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32c3_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_UPESY_ESP32C3_MINI",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
+    "f_cpu": "160000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0X303A",
+        "0x819B"
+      ]
+    ],
+    "mcu": "esp32c3",
+    "variant": "uPesy_esp32c3_mini"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32c3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "uPesy ESP32C3 Mini",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.upesy.com/products/upesy-esp32c3-mini-low-power",
+  "vendor": "uPesy"
+}

--- a/boards/upesy_esp32s3_basic.json
+++ b/boards/upesy_esp32s3_basic.json
@@ -1,0 +1,50 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_16MB.csv",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_UPESY_ESP32S3_BASIC",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x8192"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "uPesy_esp32s3_basic"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "uPesy ESP32S3 Basic",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,    
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.upesy.com/products/esp32s3-devkit-board",
+  "vendor": "uPesy"
+}

--- a/boards/upesy_wroom.json
+++ b/boards/upesy_wroom.json
@@ -32,6 +32,6 @@
     "require_upload_port": true,
     "speed": 460800
   },
-  "url": "https://www.upesy.fr/products/upesy-esp32-wroom-devkit-board",
+  "url": "https://www.upesy.com/products/upesy-esp32-wroom-devkit-board",
   "vendor": "uPesy"
 }

--- a/boards/upesy_wrover.json
+++ b/boards/upesy_wrover.json
@@ -31,7 +31,7 @@
   ],
   "name": "uPesy ESP32 Wrover DevKit",
   "upload": {
-    "flash_size": "4MB",
+    "flash_size": "16MB",
     "maximum_ram_size": 327680,
     "maximum_size": 16777216,
     "require_upload_port": true,

--- a/boards/upesy_wrover.json
+++ b/boards/upesy_wrover.json
@@ -33,10 +33,10 @@
   "upload": {
     "flash_size": "4MB",
     "maximum_ram_size": 327680,
-    "maximum_size": 4194304,
+    "maximum_size": 16777216,
     "require_upload_port": true,
     "speed": 460800
   },
-  "url": "https://www.upesy.fr/products/upesy-esp32-wrover-devkit-board",
+  "url": "https://www.upesy.com/products/upesy-esp32-wrover-devkit-board",
   "vendor": "uPesy"
 }


### PR DESCRIPTION
- Update info for : uPesy Wroom and Wrover variants
- Add these boards that are merged in the Arduino-ESP32 repo https://github.com/espressif/arduino-esp32/pull/8778 :
  - uPesy EDU ESP32
  - uPesy ESP32C3 Basic
  - uPesy ESP32C3 Mini
  - uPesy ESP32S3 Basic
  
