### PR TITLE
Fix Lolin S2 USB CDC setup

### DIFF
--- a/boards/lolin_s2_mini.json
+++ b/boards/lolin_s2_mini.json
@@ -7,7 +7,8 @@
     "extra_flags": [
       "-DARDUINO_LOLIN_S2_MINI",
       "-DBOARD_HAS_PSRAM",
-      "-DARDUINO_USB_CDC_ON_BOOT=1"
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_USB_MODE=0"
     ],
     "f_cpu": "240000000L",
     "f_flash": "80000000L",


### PR DESCRIPTION
This commit fixes an issue with this board pointed out in ESP32 Arduino Github.

https://github.com/espressif/arduino-esp32/issues/8977