### PR TITLE
Add Adafruit QT Py ESP32-S3 (PSRAM version)

### DIFF
--- a/boards/adafruit_qtpy_esp32s3_n4r2.json
+++ b/boards/adafruit_qtpy_esp32s3_n4r2.json
@@ -1,0 +1,66 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "partitions-4MB-tinyuf2.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ADAFRUIT_QTPY_ESP32S3_N4R2",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x239A",
+        "0x8143"
+      ],
+      [
+        "0x239A",
+        "0x0143"
+      ],
+      [
+        "0x239A",
+        "0x8144"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "adafruit_qtpy_esp32s3_n4r2"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Adafruit QT Py ESP32-S3 (4M Flash 2M PSRAM)",
+  "upload": {
+    "arduino": {
+      "flash_extra_images": [
+        [
+          "0x2d0000",
+          "variants/adafruit_qtpy_esp32s3_n4r2/tinyuf2.bin"
+        ]
+      ]
+    },
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.adafruit.com/product/5700",
+  "vendor": "Adafruit"
+}

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -44,3 +44,8 @@ monitor_speed = 115200
 platform = espressif32
 framework = arduino
 board = arduino_nano_esp32
+
+[env:adafruit_qtpy_esp32s3_n4r2]
+platform = espressif32
+board = adafruit_qtpy_esp32s3_n4r2
+framework = arduino


### PR DESCRIPTION
Per https://community.platformio.org/t/adafruit-qt-py-s3-with-2mb-psram/37256. The repo only has the "No PSRAM" version, but the "N4R2" version with builtin 2MB PSRAM is missing. 

Per forum thread this was tested by one user to be working. I did not further test on hardware.