### PR TITLE
Support Arduino ESP32 alpha v3.0.0 based on ESP-IDF v5.1

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -81,6 +81,12 @@
       "owner": "platformio",
       "version": "~3.20014.0"
     },
+    "framework-arduinoespressif32-libs": {
+      "type": "sdk",
+      "optional": true,
+      "owner": "espressif",
+      "version": "~5.1.0"
+    },
     "framework-arduino-mbcwb": {
       "type": "framework",
       "optional": true,

--- a/platform.py
+++ b/platform.py
@@ -342,6 +342,7 @@ class Espressif32Platform(PlatformBase):
             )
 
         toolchain_remap = {
+            "esp32-arduino-libs": "framework-arduinoespressif32-libs",
             "xtensa-esp32-elf-gcc": "toolchain-xtensa-esp32",
             "xtensa-esp32s2-elf-gcc": "toolchain-xtensa-esp32s2",
             "xtensa-esp32s3-elf-gcc": "toolchain-xtensa-esp32s3",
@@ -401,6 +402,8 @@ class Espressif32Platform(PlatformBase):
             self.packages[toolchain_package]["version"] = version
             self.packages[toolchain_package]["owner"] = "espressif"
             self.packages[toolchain_package]["type"] = "toolchain"
+            if (toolchain_package == "framework-arduinoespressif32-libs"):
+                self.packages[toolchain_package]["optional"] = False
 
     def configure_upstream_arduino_packages(self, url_items):
         framework_index_file = os.path.join(

--- a/platform.py
+++ b/platform.py
@@ -321,6 +321,7 @@ class Espressif32Platform(PlatformBase):
                 r"^gcc(?P<MAJOR>\d+)_(?P<MINOR>\d+)_(?P<PATCH>\d+)-esp-(?P<EXTRA>.+)$",
                 r"^esp-(?P<EXTRA>.+)-(?P<MAJOR>\d+)\.(?P<MINOR>\d+)\.?(?P<PATCH>\d+)$",
                 r"^esp-(?P<MAJOR>\d+)\.(?P<MINOR>\d+)\.(?P<PATCH>\d+)(_(?P<EXTRA>.+))?$",
+                r"^idf-release_v(?P<MAJOR>\d+)\.(?P<MINOR>\d+)(.(?P<PATCH>\d+))?(-(?P<EXTRA>.+))?$",
             )
             for pattern in version_patterns:
                 match = re.search(pattern, original_version)
@@ -328,7 +329,7 @@ class Espressif32Platform(PlatformBase):
                     result = "%s.%s.%s" % (
                         match.group("MAJOR"),
                         match.group("MINOR"),
-                        match.group("PATCH"),
+                        match.group("PATCH") if match.group("PATCH") is not None else "0",
                     )
                     if match.group("EXTRA"):
                         result = result + "+%s" % match.group("EXTRA")


### PR DESCRIPTION
PlatformIO already supports overriding platform packages to use an alternative or development version of a package, however a missing library dependency means this doesn't work for arduino-esp32 alpha v3.0.0.

This PR adds a reference to framework-arduinoespressif32-libs SDK (aka esp32-arduino-libs), so that the latest arduino-esp32 alpha can be used. But only if you override platform packages to the alpha 3.0.0 version, which references libs, and also point at the libs location.

The change is backwards compatible, i.e. does not break any existing code, as the library framework-arduinoespressif32-libs is only included if it is referenced in an overridden arduino-esp32 manifest.

This fixes issue #1225 and #1211, i.e. if you are getting the error "KeyError: 'framework-arduinoespressif32-libs':" due to the missing library (when you reference an alpha v3 version of arduino-esp32)

To use, configure your project to reference the latest arduino-esp32, which will include a reference to framework-arduinoespressif32-libs. You also need to override the location of the libs (as they are not currently in the PlatformIO repository).

```
platform = https://github.com/sgryphon/platform-espressif32.git#sgryphon/add-esp32-arduino-libs
platform_packages =
    platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#master
    platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/esp32-arduino-libs.git#idf-release/v5.1
```

If you use a older version of the platform package, e.g. the default, then libs are not needed, and won't be loaded. So the following also works fine (old version of platform package, no libs), or any override of the esp32-arduino platform package that does not include the libs (i.e. pre alpha v3) will also work:

```
platform = https://github.com/sgryphon/platform-espressif32.git#sgryphon/add-esp32-arduino-libs
platform_packages =
```

This change simply allows the arduino-esp32 platform package to be configured with alpha 3.0.0, if you want to test some advanced development (without affecting existing support).

Future work: The library dependency needs to be added to the PlatformIO Registry, and when 3.0.0 is released/stable, the dependency can be made Optional = False as the default.

**Note:** This change doesn't necessarily mean your code will work, only that the missing dependency will be there. Alpha 3.0.0 has breaking changes, so existing code/libraries may not be compatible. The esp32-arduino package does have some basic examples that do work, and are run as part of their integrations tests. https://github.com/espressif/arduino-esp32/blob/e4d6a8abf9fab7422e21f72d3aeb2e9c9484ab36/.github/scripts/on-push.sh#L92


