### PR TITLE
Add support for Lilka (v2) board

### DIFF
--- a/boards/lilka_v2.json
+++ b/boards/lilka_v2.json
@@ -1,0 +1,60 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi",
+      "partitions": "default_16MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_LILKA",
+      "-DLILKA_VERSION=2",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x239A",
+        "0x8145"
+      ],
+      [
+        "0x239A",
+        "0x0145"
+      ],
+      [
+        "0x239A",
+        "0x8146"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Lilka v2",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://github.com/and3rson/lilka",
+  "vendor": "Anderson & friends"
+}
+


### PR DESCRIPTION
This PR adds a new board - `Lilka v2`.

Lilka is an open-source community-driven DIY project based on `ESP32-S3-WROOM-1-N16R8`.

- Project monorepo: https://github.com/and3rson/lilka
- Docs (Ukrainian): https://lilka.readthedocs.io/uk/latest

We are expecting a lot of people to use it with `platformio`, thus having it in this repository would greatly simplify the set-up for new developers.

Thanks in advance, and please let me know if my configuration is missing anything!

**EDIT**: the reason for starting with  `v2` is that `v1` is an internal prototype that was demonstrated to research the feasibility of developing a stable model (`v2`). Thus the first public version is `v2`. So in order to avoid confusion, we're explicitly naming it `lilka_v2`.

Furthermore, `v3` is likely going to be developed in future being potentially backwards-incompatible, so including hardware version as part of board's name ensures long-term support for all versions.