### PR TITLE
Bump idf-component-manager to 1.5.2

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1117,7 +1117,7 @@ def install_python_deps():
         "future": ">=0.18.3",
         "pyparsing": "~=3.0.9" if IDF5 else ">=2.0.3,<2.4.0",
         "kconfiglib": "~=14.1.0" if IDF5 else "~=13.7.1",
-        "idf-component-manager": "~=1.2.3" if IDF5 else "~=1.0",
+        "idf-component-manager": "~=1.5.2" if IDF5 else "~=1.0",
         "esp-idf-kconfig": "~=1.2.0"
     }
 


### PR DESCRIPTION
The 1.4.0 of idf-component-manager introduces the "license"-tag which works the same as the library.json "license"-tag. 
Several libraries have already started to use this and I just bumped into this with my Robusto library, and when helping Radiolib getting in there. (Edit: saw that arduino-esp32 also use it)

The problem is that libraries before this instead fails, and thus the Platformio build fails, and the recommendation to update to a newer version doesn't help as the old one is installed again in the venv anyway (which actually makes the recommendation sort of pointless and misleading)
I am seeing no issue with going with the latest version here, it is not new either and seems stable. 

**Temporary workaround:**
An ugly one for those that needs this fix before nest platform-espressif-release, at least for *nix variants:
Do the suggested venv idf-component update (not the system one) using sudo, that way the platformio build fails reinstalling the "old" idf-component-manager, but still completes the build process. 
`sudo -H ~/.platformio/penv/.espidf-5.1.2/bin/python -m pip install --upgrade idf-component-manager`
_Note that you will have to remove the .espidf-5.1.2 folder to make it reinstall later on_