### PR TITLE
Use GCC wrapped ar & ranlib to enable LTO

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -241,7 +241,7 @@ env.Replace(
     __get_board_flash_mode=_get_board_flash_mode,
     __get_board_memory_type=_get_board_memory_type,
 
-    AR="%s-elf-ar" % toolchain_arch,
+    AR="%s-elf-gcc-ar" % toolchain_arch,
     AS="%s-elf-as" % toolchain_arch,
     CC="%s-elf-gcc" % toolchain_arch,
     CXX="%s-elf-g++" % toolchain_arch,
@@ -257,7 +257,7 @@ env.Replace(
     ) if env.get("PIOFRAMEWORK") == ["espidf"] else "%s-elf-gdb" % toolchain_arch,
     OBJCOPY=join(
         platform.get_package_dir("tool-esptoolpy") or "", "esptool.py"),
-    RANLIB="%s-elf-ranlib" % toolchain_arch,
+    RANLIB="%s-elf-gcc-ranlib" % toolchain_arch,
     SIZETOOL="%s-elf-size" % toolchain_arch,
 
     ARFLAGS=["rc"],


### PR DESCRIPTION
As per https://github.com/platformio/platform-ststm32/issues/386

Link Time Optimisation shifts compilation to the final link, allowing for more aggressive optimisations.

AR & RANLIB need to use their gcc equivalents to enable this, and will otherwise behave identically if LTO data is not in the objects.

(This should probably be done for all platforms)