### PR TITLE
Create Board Definition for Waveshare ESP32-S3 with 1.28 in Display

### DIFF
--- a/boards/esp32-s3-touch-lcd-1.28.json
+++ b/boards/esp32-s3-touch-lcd-1.28.json
@@ -1,0 +1,51 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_8MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32_S3_TOUCH_LCD_128",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "1A86",
+        "55D3"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Waveshare ESP32-S3-Touch-LCD-1.28",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.waveshare.com/esp32-s3-touch-lcd-1.28.htm",
+  "vendor": "Waveshare"
+}


### PR DESCRIPTION
Add board definition for:
https://www.waveshare.com/esp32-s3-touch-lcd-1.28.htm