### PR TITLE
Add missing Bluetooth connectivity for esp32-s3-devkitm-1

### DIFF
--- a/boards/esp32-s3-devkitm-1.json
+++ b/boards/esp32-s3-devkitm-1.json
@@ -24,6 +24,7 @@
     "variant": "esp32s3"
   },
   "connectivity": [
+    "bluetooth",
     "wifi"
   ],
   "debug": {


### PR DESCRIPTION
esp32-s3-devkitm-1 was overseen when adding bluetooth in f6ec3926f9f660ee9abada8540ffe1e205da4bbf