### PR TITLE
Add ThingPulse ePulse Feather and ePulse Feather C6 board definition

### DIFF
--- a/boards/thingpulse_epulse_feather.json
+++ b/boards/thingpulse_epulse_feather.json
@@ -5,7 +5,7 @@
     },
     "core": "esp32",
     "extra_flags": [
-      "-DARDUINO_ESP32_DEV",
+      "-DARDUINO_THINGPULSE_EPULSE_FEATHER",
       "-DBOARD_HAS_PSRAM",
       "-DARDUINO_RUNNING_CORE=1",
       "-DARDUINO_EVENT_RUNNING_CORE=1",
@@ -16,7 +16,7 @@
     "f_flash": "80000000L",
     "flash_mode": "dio",
     "mcu": "esp32",
-    "variant": "thingpulse_epulse_feather_c6"
+    "variant": "thingpulse_epulse_feather"
   },
   "connectivity": [
     "wifi",

--- a/boards/thingpulse_epulse_feather_c6.json
+++ b/boards/thingpulse_epulse_feather_c6.json
@@ -5,10 +5,18 @@
     "f_flash": "80000000L",
     "flash_mode": "qio",
     "mcu": "esp32c6",
-    "variant": "thingpulse_epulse_feather_c6"
+    "variant": "thingpulse_epulse_feather_c6",
+    "extra_flags": [
+        "-DARDUINO_THINGPULSE_EPULSE_FEATHER_C6",
+        "-DARDUINO_USB_CDC_ON_BOOT=1",
+        "-DARDUINO_USB_MODE=1"
+    ]
   },
   "connectivity": [
-    "wifi"
+    "wifi",
+    "bluetooth",
+    "zigbee",
+    "thread"
   ],
   "debug": {
     "openocd_target": "esp32c6.cfg"


### PR DESCRIPTION
Both boards are already on the arduino-esp32 repository:

- https://github.com/espressif/arduino-esp32/blob/master/variants/thingpulse_epulse_feather/pins_arduino.h
- https://github.com/espressif/arduino-esp32/blob/master/variants/thingpulse_epulse_feather_c6/pins_arduino.h

Source:
- https://thingpulse.com/product/epulse-feather-low-power-esp32-development-board/
- https://thingpulse.com/product/epulse-feather-low-power-esp32-c6/