### PR TITLE
Add board ESP32-S3 PowerFeather

### DIFF
--- a/boards/esp32s3_powerfeather.json
+++ b/boards/esp32s3_powerfeather.json
@@ -1,0 +1,50 @@
+{
+  "build": {
+    "arduino":{
+      "partitions": "default_8MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32S3_POWERFEATHER",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0X303A",
+        "0x81BB"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3_powerfeather"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "ESP32-S3 PowerFeather",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://powerfeather.dev/",
+  "vendor": "PowerFeather"
+}
+

--- a/boards/esp32s3_powerfeather.json
+++ b/boards/esp32s3_powerfeather.json
@@ -8,8 +8,7 @@
       "-DARDUINO_ESP32S3_POWERFEATHER",
       "-DARDUINO_USB_CDC_ON_BOOT=1",
       "-DARDUINO_RUNNING_CORE=1",
-      "-DARDUINO_EVENT_RUNNING_CORE=1",
-      "-DBOARD_HAS_PSRAM"
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
     ],
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
@@ -39,7 +38,6 @@
     "flash_size": "8MB",
     "maximum_ram_size": 327680,
     "maximum_size": 8388608,
-    "use_1200bps_touch": true,
     "wait_for_upload_port": true,
     "require_upload_port": true,
     "speed": 460800


### PR DESCRIPTION
Adds support for ESP32-S3 PowerFeather (https://powerfeather.dev/). Board uses an 8MB flash, 2MB PSRAM ESP32-S3 module.

Board is supported since [Arduino ESP32 2.0.15 release](https://github.com/espressif/arduino-esp32/releases/tag/2.0.15), see merged PRs https://github.com/espressif/arduino-esp32/pull/9325 and https://github.com/espressif/arduino-esp32/pull/9398. Support PR's for the 3.x series has also been merged in https://github.com/espressif/arduino-esp32/pull/8889, https://github.com/espressif/arduino-esp32/pull/9052 and https://github.com/espressif/arduino-esp32/pull/9431 and should be in the next release.

Arduino variant is `esp32s3_powerfeather` with board name `ESP32S3_POWERFEATHER` (see https://github.com/espressif/arduino-esp32/blob/master/boards.txt#L35200-L35201)


ESP-IDF is also supported, but pin definitions are in the accompaniment library, [powerfeather-sdk](https://github.com/PowerFeather/powerfeather-sdk).


