### PR TITLE
feat: make esp32_exception_decoder more generic

### DIFF
--- a/monitor/filter_exception_decoder.py
+++ b/monitor/filter_exception_decoder.py
@@ -56,7 +56,7 @@ See https://docs.platformio.org/page/projectconf/build_configurations.html
     def setup_paths(self):
         self.project_dir = os.path.abspath(self.project_dir)
         try:
-            data = load_build_metadata(self.project_dir, self.environment)
+            data = load_build_metadata(self.project_dir, self.environment, cache=True)
             self.firmware_path = data["prog_path"]
             if not os.path.isfile(self.firmware_path):
                 sys.stderr.write(

--- a/monitor/filter_exception_decoder.py
+++ b/monitor/filter_exception_decoder.py
@@ -32,8 +32,9 @@ IS_WINDOWS = sys.platform.startswith("win")
 class Esp32ExceptionDecoder(DeviceMonitorFilterBase):
     NAME = "esp32_exception_decoder"
 
-    BACKTRACE_PATTERN = re.compile(r"^Backtrace:(((\s?0x[0-9a-fA-F]{8}:0x[0-9a-fA-F]{8}))+)")
-    BACKTRACE_ADDRESS_PATTERN = re.compile(r'0x[0-9a-fA-F]{8}:0x[0-9a-fA-F]{8}')
+    ADDR_PATTERN = re.compile(r"((?:0x[0-9a-fA-F]{8}[: ]?)+)\s?$")
+    ADDR_SPLIT = re.compile(r"[ :]")
+    PREFIX_RE = re.compile(r"^ *")
 
     def __call__(self):
         self.buffer = ""
@@ -57,6 +58,7 @@ See https://docs.platformio.org/page/projectconf/build_configurations.html
         self.project_dir = os.path.abspath(self.project_dir)
         try:
             data = load_build_metadata(self.project_dir, self.environment, cache=True)
+
             self.firmware_path = data["prog_path"]
             if not os.path.isfile(self.firmware_path):
                 sys.stderr.write(
@@ -100,38 +102,65 @@ See https://docs.platformio.org/page/projectconf/build_configurations.html
                 self.buffer = ""
             last = idx + 1
 
-            m = self.BACKTRACE_PATTERN.match(line)
+            m = self.ADDR_PATTERN.search(line)
             if m is None:
                 continue
 
-            trace = self.get_backtrace(m)
-            if len(trace) != "":
+            trace = self.build_backtrace(line, m.group(1))
+            if trace:
                 text = text[: idx + 1] + trace + text[idx + 1 :]
                 last += len(trace)
         return text
 
-    def get_backtrace(self, match):
-        trace = "\n"
+    def is_address_ignored(self, address):
+        return address in ("", "0x00000000")
+
+    def filter_addresses(self, adresses_str):
+        addresses = self.ADDR_SPLIT.split(adresses_str)
+        size = len(addresses)
+        while size > 1 and self.is_address_ignored(addresses[size-1]):
+            size -= 1
+        return addresses[:size]
+
+    def build_backtrace(self, line, address_match):
+        addresses = self.filter_addresses(address_match)
+        if not addresses:
+            return ""
+
+        prefix_match = self.PREFIX_RE.match(line)
+        prefix = prefix_match.group(0) if prefix_match is not None else ""
+
+        trace = ""
         enc = "mbcs" if IS_WINDOWS else "utf-8"
         args = [self.addr2line_path, u"-fipC", u"-e", self.firmware_path]
         try:
-            for i, addr in enumerate(self.BACKTRACE_ADDRESS_PATTERN.findall(match.group(1))):
+            i = 0
+            for addr in addresses:
                 output = (
                     subprocess.check_output(args + [addr])
                     .decode(enc)
                     .strip()
                 )
+
+                # newlines happen with inlined methods
                 output = output.replace(
                     "\n", "\n     "
-                )  # newlines happen with inlined methods
+                )
+
+                # throw out addresses not from ELF
+                if output == "?? ??:0":
+                    continue
+
                 output = self.strip_project_dir(output)
-                trace += "  #%-2d %s in %s\n" % (i, addr, output)
+                trace += "%s  #%-2d %s in %s\n" % (prefix, i, addr, output)
+                i += 1
         except subprocess.CalledProcessError as e:
             sys.stderr.write(
                 "%s: failed to call %s: %s\n"
                 % (self.__class__.__name__, self.addr2line_path, e)
             )
-        return trace
+
+        return trace + "\n" if trace else ""
 
     def strip_project_dir(self, trace):
         while True:


### PR DESCRIPTION
* The official idf.py monitor just tries to decode any 4 byte hex number it finds.
  This variant safely decodes backtraces as well as heap tracing dumps.

Backtrace with new version:
```
Backtrace: 0x400d3e44:0x3ffb2190 0x4008ba5c:0x3ffb2200 0x4008f085:0x3ffb2230
  #0  0x400d3e44 in app_main at src/main.cpp:71 (discriminator 2)
  #1  0x4008ba5c in main_task at /home/tassadar/.platformio/packages/framework-espidf/components/freertos/app_startup.c:208 (discriminator 13)
  #2  0x4008f085 in vPortTaskWrapper at /home/tassadar/.platformio/packages/framework-espidf/components/freertos/FreeRTOS-Kernel/portable/xtensa/port.c:134
```

Heap tracing dump:
```
====== Heap Trace: 1 records (100 capacity) ======
   168 bytes (@ 0x3ffd0dd0, Internal) allocated CPU 0 ccount 0x7d7ee5e8 caller 0x4013bfc4:0x4013bfd8:0x400d3e1d:0x4008ba5f:0x4008f088:
     #0  0x4013bfc4 in operator new(unsigned int) at /builds/idf/crosstool-NG/.build/xtensa-esp32-elf/src/gcc/libstdc++-v3/libsupc++/new_op.cc:50
     #1  0x4013bfd8 in operator new[](unsigned int) at /builds/idf/crosstool-NG/.build/xtensa-esp32-elf/src/gcc/libstdc++-v3/libsupc++/new_opv.cc:33
     #2  0x400d3e1d in app_main at src/main.cpp:64 (discriminator 2)
     #3  0x4008ba5f in main_task at /home/tassadar/.platformio/packages/framework-espidf/components/freertos/app_startup.c:209 (discriminator 13)
     #4  0x4008f088 in vPortTaskWrapper at /home/tassadar/.platformio/packages/framework-espidf/components/freertos/FreeRTOS-Kernel/portable/xtensa/port.c:136

freed by 0x4014e7f8:0x4013bf68:0x400d3e29:0x4008ba5f:0x4008f088:0x00000000:0x00000000:0x00000000:0x00000000:0x00000000
  #0  0x4014e7f8 in operator delete(void*) at /builds/idf/crosstool-NG/.build/xtensa-esp32-elf/src/gcc/libstdc++-v3/libsupc++/del_op.cc:50
  #1  0x4013bf68 in operator delete[](void*) at /builds/idf/crosstool-NG/.build/xtensa-esp32-elf/src/gcc/libstdc++-v3/libsupc++/del_opv.cc:36
  #2  0x400d3e29 in app_main at src/main.cpp:66
  #3  0x4008ba5f in main_task at /home/tassadar/.platformio/packages/framework-espidf/components/freertos/app_startup.c:209 (discriminator 13)
  #4  0x4008f088 in vPortTaskWrapper at /home/tassadar/.platformio/packages/framework-espidf/components/freertos/FreeRTOS-Kernel/portable/xtensa/port.c:136

====== Heap Trace Summary ======
Mode: Heap Trace All
0 bytes alive in trace (0/1 allocations)
records: 1 (100 capacity, 83 high water mark)
total allocations: 1
total frees: 1
================================
```