### PR TITLE
change `build.esp-idf.preserve_source_file_extension` to `True`

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -691,7 +691,7 @@ def compile_source_files(
                     obj_path = os.path.join(obj_path, os.path.basename(src_path))
 
             preserve_source_file_extension = board.get(
-                "build.esp-idf.preserve_source_file_extension", False
+                "build.esp-idf.preserve_source_file_extension", True
             )
 
             objects.append(


### PR DESCRIPTION
as default. It avoid issues like this https://github.com/espressif/esp-dsp/issues/74
