### PR TITLE
Fix wt32-eth01.json

### DIFF
--- a/boards/wt32-eth01.json
+++ b/boards/wt32-eth01.json
@@ -9,7 +9,7 @@
     ],
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "qio",
+    "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "wt32-eth01"
   },


### PR DESCRIPTION
wt32-eth01 in esp-idf wont boot with qio flash mode and ethernet configured.

Some pins for QIO flash appear to be muxed with ethernet MAC. Given this a dedicated ethernet board, set flash mode back to 'dio'.