### PR TITLE
feat: add support for WeAct Studio ESP32C3

### DIFF
--- a/boards/weact_studio_esp32c3.json
+++ b/boards/weact_studio_esp32c3.json
@@ -1,0 +1,45 @@
+{
+    "name": "WeAct Studio ESP32-C3",
+    "vendor": "WeAct Studio",
+    "url": "https://github.com/WeActStudio/WeActStudio.ESP32C3CoreBoard",
+    "frameworks": [
+        "arduino",
+        "espidf"
+    ],
+    "connectivity": [
+        "wifi",
+        "bluetooth"
+    ],
+    "build": {
+        "mcu": "esp32c3",
+        "core": "esp32",
+        "variant": "weact_studio_esp32c3",
+        "f_cpu": "160000000L",
+        "f_flash": "80000000L",
+        "flash_mode": "qio",
+        "hwids": [
+            [
+              "0X303A",
+              "0x1001"
+            ]
+        ],
+        "extra_flags": [
+            "-DARDUINO_WEACT_STUDIO_ESP32C3",
+            "-DARDUINO_USB_MODE=1",
+            "-DARDUINO_USB_CDC_ON_BOOT=1"
+        ],
+        "arduino":{
+            "ldscript": "esp32c3_out.ld"
+        }
+    },
+    "upload": {
+        "flash_size": "4MB",
+        "maximum_ram_size": 327680,
+        "maximum_size": 4194304,
+        "require_upload_port": true,
+        "speed": 460800
+    },
+    "debug": {
+        "openocd_target": "esp32c3.cfg"
+    }
+}


### PR DESCRIPTION
Add support for [WeAct Studio ESP32C3](https://github.com/WeActStudio/WeActStudio.ESP32C3CoreBoard) board

Related: https://github.com/espressif/arduino-esp32/pull/9653