### PR TITLE
Added Board definition for M5Stack Core Basic 16MB variant

### DIFF
--- a/boards/m5stack-core-esp32-16M.json
+++ b/boards/m5stack-core-esp32-16M.json
@@ -1,0 +1,34 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_M5Stack_Core_ESP32",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "mcu": "esp32",
+    "variant": "m5stack_core_esp32"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "M5Stack Core ESP32 16M",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 532480,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "http://www.m5stack.com",
+  "vendor": "M5Stack"
+}


### PR DESCRIPTION
https://docs.m5stack.com/en/core/basic

According to the documentation (see Version Change) around 2020 the M5Stack Core Basic got upgraded to 16MB Flash. This also covers the newer versions with the SKUs K001-V27 and K001-V26.