### PR TITLE
more failsafe IDF version get

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -999,24 +999,38 @@ def find_default_component(target_configs):
     env.Exit(1)
 
 
-def get_version_cmake_file():
-    version_cmake = os.path.join(FRAMEWORK_DIR, "tools", "cmake", "version.cmake")
-    with open(version_cmake, "r") as file:
-        string = file.read().replace("\n", "").replace("(", " ").replace(")", " ")
-        list = string.split()
-        v_major = list[(list.index("IDF_VERSION_MAJOR"))+1]
-        v_minor = list[(list.index("IDF_VERSION_MINOR"))+1]
-        v_patch = list[(list.index("IDF_VERSION_PATCH"))+1]
-        version = v_major + "." + v_minor + "." + v_patch
-        return version
+def get_framework_version():
+    def _extract_from_cmake_version_file():
+        version_cmake_file = os.path.join(
+            FRAMEWORK_DIR, "tools", "cmake", "version.cmake"
+        )
+        if not os.path.isfile(version_cmake_file):
+            return
+
+        with open(version_cmake_file, encoding="utf8") as fp:
+            pattern = r"set\(IDF_VERSION_(MAJOR|MINOR|PATCH) (\d+)\)"
+            matches = re.findall(pattern, fp.read())
+            if len(matches) != 3:
+                return
+            # If found all three parts of the version
+            return ".".join([match[1] for match in matches])
+
+    pkg = platform.get_package("framework-espidf")
+    version = get_original_version(str(pkg.metadata.version.truncate()))
+    if not version:
+        # Fallback value extracted directly from the cmake version file
+        version = _extract_from_cmake_version_file()
+        if not version:
+            version = "0.0.0"
+
+    return version
 
 
 def create_version_file():
     version_file = os.path.join(FRAMEWORK_DIR, "version.txt")
     if not os.path.isfile(version_file):
         with open(version_file, "w") as fp:
-            version = get_version_cmake_file()
-            fp.write(version)
+            fp.write(get_framework_version())
 
 
 def generate_empty_partition_image(binary_path, image_size):
@@ -1248,8 +1262,10 @@ def get_idf_venv_dir():
     # unnecessary reinstallation of Python dependencies in cases when Arduino
     # as an IDF component requires a different version of the IDF package and
     # hence a different set of Python deps or their versions
-    idf_version = get_version_cmake_file()
-    return os.path.join(env.subst("$PROJECT_CORE_DIR"), "penv", ".espidf-" + idf_version)
+    idf_version = get_framework_version()
+    return os.path.join(
+        env.subst("$PROJECT_CORE_DIR"), "penv", ".espidf-" + idf_version
+    )
 
 
 def ensure_python_venv_available():

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -999,12 +999,24 @@ def find_default_component(target_configs):
     env.Exit(1)
 
 
+def get_version_cmake_file():
+    version_cmake = os.path.join(FRAMEWORK_DIR, "tools", "cmake", "version.cmake")
+    with open(version_cmake, "r") as file:
+        string = file.read().replace("\n", "").replace("(", " ").replace(")", " ")
+        list = string.split()
+        v_major = list[(list.index("IDF_VERSION_MAJOR"))+1]
+        v_minor = list[(list.index("IDF_VERSION_MINOR"))+1]
+        v_patch = list[(list.index("IDF_VERSION_PATCH"))+1]
+        version = v_major + "." + v_minor + "." + v_patch
+        return version
+
+
 def create_version_file():
     version_file = os.path.join(FRAMEWORK_DIR, "version.txt")
     if not os.path.isfile(version_file):
         with open(version_file, "w") as fp:
-            package_version = platform.get_package_version("framework-espidf")
-            fp.write(get_original_version(package_version) or package_version)
+            version = get_version_cmake_file()
+            fp.write(version)
 
 
 def generate_empty_partition_image(binary_path, image_size):
@@ -1236,10 +1248,8 @@ def get_idf_venv_dir():
     # unnecessary reinstallation of Python dependencies in cases when Arduino
     # as an IDF component requires a different version of the IDF package and
     # hence a different set of Python deps or their versions
-    idf_version = get_original_version(platform.get_package_version("framework-espidf"))
-    return os.path.join(
-        env.subst("$PROJECT_CORE_DIR"), "penv", ".espidf-" + idf_version
-    )
+    idf_version = get_version_cmake_file()
+    return os.path.join(env.subst("$PROJECT_CORE_DIR"), "penv", ".espidf-" + idf_version)
 
 
 def ensure_python_venv_available():


### PR DESCRIPTION
to make it possible to use a github repo as source for espressif IDF.

- Fixes https://github.com/platformio/platform-espressif32/issues/1418

To use a git repo it is necessary to add a package.json in the root of the used branch.