### PR TITLE
add littlefs partition subtype

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -204,7 +204,7 @@ def _to_unix_slashes(path):
 def fetch_fs_size(env):
     fs = None
     for p in _parse_partitions(env):
-        if p["type"] == "data" and p["subtype"] in ("spiffs", "fat"):
+        if p["type"] == "data" and p["subtype"] in ("spiffs", "fat", "littlefs"):
             fs = p
     if not fs:
         sys.stderr.write(


### PR DESCRIPTION
Added "littlefs" to list of recognised subtypes in  _parse_partitions so that partition table configurations using littleFS build successfully.
See https://community.platformio.org/t/build-filesystem-image-fails-for-littlefs-partition/41709