### PR TITLE
Add board def for Adafruit Feather ESP32-C6

### DIFF
--- a/boards/adafruit_feather_esp32c6.json
+++ b/boards/adafruit_feather_esp32c6.json
@@ -1,0 +1,47 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32c6_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ADAFRUIT_FEATHER_ESP32C6",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
+    "f_cpu": "160000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0X303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32c6",
+    "variant": "adafruit_feather_esp32c6"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "zigbee",
+    "thread"
+  ],
+  "debug": {
+    "openocd_target": "esp32c6.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Adafruit Feather ESP32-C6",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.adafruit.com/product/5933",
+  "vendor": "Adafruit"
+}


### PR DESCRIPTION
This adds the Adafruit Feather ESP32-C6 (4mb variant no psram).

About to test it and then will make non-draft. Also need to confirm the board define is correct.

Should match up to https://github.com/espressif/arduino-esp32/tree/master/variants/adafruit_feather_esp32c6