### PR TITLE
Add board definition for Freenove ESP32-S3-WROOM

### DIFF
--- a/boards/freenove_esp32_s3_wroom.json
+++ b/boards/freenove_esp32_s3_wroom.json
@@ -1,0 +1,55 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_8MB.csv",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32S3_DEV",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DBOARD_HAS_PSRAM",    
+      "-DARDUINO_USB_MODE=0",
+      "-DARDUINO_USB_CDC_ON_BOOT=0"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "psram_type": "opi",
+    "hwids": [
+      [
+        "0X303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Freenove ESP32-S3 WROOM N8R8 (8MB Flash / 8MB PSRAM)",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://github.com/Freenove/Freenove_ESP32_S3_WROOM_Board",
+  "vendor": "Freenove"
+}

--- a/boards/freenove_esp32_s3_wroom.json
+++ b/boards/freenove_esp32_s3_wroom.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "arduino":{
+    "arduino": {
       "ldscript": "esp32s3_out.ld",
       "partitions": "default_8MB.csv",
       "memory_type": "qio_opi"
@@ -20,7 +20,7 @@
     "psram_type": "opi",
     "hwids": [
       [
-        "0X303A",
+        "0x303A",
         "0x1001"
       ]
     ],


### PR DESCRIPTION
Adds support for Freenove ESP32-S3-WROOM (https://github.com/Freenove/Freenove_ESP32_S3_WROOM_Board)