### PR TITLE
feat: added seeed_xiao_esp32c6 board

### DIFF
--- a/boards/seeed_xiao_esp32c6.json
+++ b/boards/seeed_xiao_esp32c6.json
@@ -1,0 +1,48 @@
+{
+    "build": {
+      "core": "esp32",
+      "extra_flags": [
+        "-DARDUINO_XIAO_ESP32C6",
+        "-DARDUINO_USB_CDC_ON_BOOT=1",
+        "-DARDUINO_USB_MODE=1"
+      ],
+      "f_cpu": "160000000L",
+      "f_flash": "80000000L",
+      "flash_mode": "qio",
+      "hwids": [
+        [
+          "0x2886",
+          "0x0048"
+        ],
+        [
+          "0x2886",
+          "0x8048"
+        ]
+      ],
+      "mcu": "esp32c6",
+      "variant": "XIAO_ESP32C6"
+    },
+    "connectivity": [
+      "wifi",
+      "bluetooth",
+      "zigbee",
+      "thread"
+    ],
+    "debug": {
+      "openocd_target": "esp32c6.cfg"
+    },
+    "frameworks": [
+      "arduino",
+      "espidf"
+    ],
+    "name": "Seeed Studio XIAO ESP32C6",
+    "upload": {
+      "flash_size": "4MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 4194304,
+      "require_upload_port": true,
+      "speed": 460800
+    },
+    "url": "https://wiki.seeedstudio.com/XIAO_ESP32C6_Getting_Started/",
+    "vendor": "Seeed Studio"
+  }


### PR DESCRIPTION
Added board
- seeed_xiao_esp32c6 


## References

- https://wiki.seeedstudio.com/xiao_esp32c6_with_platform_io/
- https://github.com/mnowak32/platform-espressif32/blob/boards/seeed_xiao_esp32c6/boards/seeed_xiao_esp32c6.json