### PR TITLE
Update heltec_wireless_stick_lite.json

### DIFF
--- a/boards/heltec_wireless_stick_lite.json
+++ b/boards/heltec_wireless_stick_lite.json
@@ -6,7 +6,7 @@
     "core": "esp32",
     "extra_flags": "-DARDUINO_HELTEC_WIRELESS_STICK_LITE",
     "f_cpu": "240000000L",
-    "f_flash": "40000000L",
+    "f_flash": "80000000L",
     "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "heltec_wireless_stick_lite"


### PR DESCRIPTION
Supports 80MHz
I get an error when using this board and a fresh install of platformio in vscode, change this speed to 80Mhz solves the problems.