### PR TITLE
Add RYMCU ESP32-Dev and ESP32-C3 board

### DIFF
--- a/boards/rymcu-esp32-c3-devkitm-1.json
+++ b/boards/rymcu-esp32-c3-devkitm-1.json
@@ -1,0 +1,35 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32c3_out.ld"
+    },
+    "core": "esp32",
+    "f_cpu": "160000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "extra_flags": "-DARDUINO_ESP32C3_DEV",
+    "mcu": "esp32c3",
+    "variant": "esp32c3"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth"
+  ],
+  "debug": {
+    "openocd_target": "esp32c3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "RYMCU ESP32-C3-DevKitM-1",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://rymcu.com/products",
+  "vendor": "RYMCU"
+}

--- a/boards/rymcu-esp32-devkitc.json
+++ b/boards/rymcu-esp32-devkitc.json
@@ -1,0 +1,37 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_ESP32_DEV",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "esp32"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "RYMCU ESP32-DevKitC",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://rymcu.com/products",
+  "vendor": "RYMCU"
+}


### PR DESCRIPTION
[RYMCU ESP32-DevKitC](https://github.com/rymcu/ESP32-Open/tree/main/ESP32-DevKitC) and [RYMCU ESP32-C3-DevKitM-1](https://github.com/rymcu/ESP32-Open/tree/main/ESP32C3-DevKitM-1) are open source boards desiged by [RYMCU](https://rymcu.com/)，based on ESP-WROOM-32 and ESP32-­C3-­MINI­-1.

<img width="2101" alt="bt1" src="https://github.com/user-attachments/assets/82460663-41a1-4523-bef0-4ce1d44fdfef">
<img width="2291" alt="tb" src="https://github.com/user-attachments/assets/4de94161-2a14-4f02-9222-e686ea61a7db">

thanks a lot.