### PR TITLE
Add support for Waveshare board ESP32-S3-Tiny

### DIFF
--- a/boards/esp32-s3-tiny.json
+++ b/boards/esp32-s3-tiny.json
@@ -1,0 +1,46 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32S3_DEV",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "waveshare_esp32s3_tiny"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "ESP32-S3-Tiny",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.waveshare.com/wiki/ESP32-S3-Tiny",
+  "vendor": "Waveshare"
+}


### PR DESCRIPTION
Description of Change
Adding variant for Waveshare ESP32-S3-Tiny board

Related links
Wiki For [ESP32-S3-Tiny](https://www.waveshare.com/wiki/ESP32-S3-Tiny)

arduino-esp32 PR [variants/waveshare_esp32_s3_tiny](https://github.com/espressif/arduino-esp32/pull/10634)
