### PR TITLE
Fixed missing psram for adafruit feather with tft

### DIFF
--- a/boards/adafruit_feather_esp32s3_tft.json
+++ b/boards/adafruit_feather_esp32s3_tft.json
@@ -2,14 +2,16 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s3_out.ld",
-      "partitions": "partitions-4MB-tinyuf2.csv"
+      "partitions": "partitions-4MB-tinyuf2.csv",
+      "memory_type": "qio_qspi"
     },
     "core": "esp32",
     "extra_flags": [
       "-DARDUINO_ADAFRUIT_FEATHER_ESP32S3_TFT",
       "-DARDUINO_USB_CDC_ON_BOOT=1",
       "-DARDUINO_RUNNING_CORE=1",
-      "-DARDUINO_EVENT_RUNNING_CORE=1"
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DBOARD_HAS_PSRAM"
     ],
     "f_cpu": "240000000L",
     "f_flash": "80000000L",


### PR DESCRIPTION
This is the same config as for the reverse tft