### PR TITLE
Add support for the Lilygo T3 S3

### DIFF
--- a/boards/lilygo-t3_s3_v1_x.json.json
+++ b/boards/lilygo-t3_s3_v1_x.json.json
@@ -1,0 +1,45 @@
+{
+    "build": {
+        "arduino": {
+            "ldscript": "esp32s3_out.ld",
+            "partitions": "default.csv",
+            "memory_type": "qio_qspi"
+        },
+        "core": "esp32",
+        "extra_flags": [
+            "-DARDUINO_LILYGO_T3_S3_V1_X",
+            "-DBOARD_HAS_PSRAM",
+            "-DARDUINO_USB_CDC_ON_BOOT=1",
+            "-DARDUINO_RUNNING_CORE=1",
+            "-DARDUINO_EVENT_RUNNING_CORE=1",
+            "-DARDUINO_USB_MODE=1"
+        ],
+        "f_cpu": "240000000L",
+        "f_flash": "80000000L",
+        "flash_mode": "qio",
+        "mcu": "esp32s3",
+        "variant": "esp32s3"
+    },
+    "connectivity": [
+        "wifi"
+    ],
+    "debug": {
+        "openocd_target": "esp32s3.cfg"
+    },
+    "frameworks": [
+        "arduino",
+        "espidf"
+    ],
+    "name": "LilyGo T3-S3 Radio",
+    "upload": {
+        "flash_size": "4MB",
+        "maximum_ram_size": 327680,
+        "maximum_size": 4194304,
+        "use_1200bps_touch": true,
+        "wait_for_upload_port": true,
+        "require_upload_port": true,
+        "speed": 460800
+    },
+    "url": "https://www.lilygo.cc",
+    "vendor": "LilyGo"
+}


### PR DESCRIPTION
Adds support for the Lilygo T3 S3: https://lilygo.cc/products/t3s3-v1-0
The configuration file was taken from: https://github.com/Xinyuan-LilyGO/LilyGo-LoRa-Series/blob/master/boards/t3_s3_v1_x.json