### PR TITLE
Add Shelly3Pro

### DIFF
--- a/boards/shelly3pro.json
+++ b/boards/shelly3pro.json
@@ -1,0 +1,37 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32_out.ld",
+      "partitions": "default_8MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_ESP32_EVB",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "mcu": "esp32",
+    "variant": "shelly3pro_esp32"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet"
+  ],
+  "debug": {
+    "openocd_board": "esp32-wroom.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Shelly3Pro ESP32",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.shelly.com/products/shelly-pro-3",
+  "vendor": "Shelly"
+}


### PR DESCRIPTION
Add the Shelly3Pro, as found in the Shelly Pro 3. This is a custom designed ESP32 board with 8MiB flash, and SMSC 8720A Ethernet PHY. All other I/O is on separate boards via pin-headers and thus not relevant.

The board has no flashing circuity and requires 'manual' toggling of reset and GPIO0.