### PR TITLE
Add support for ESP32-S3-DevKitC-1-N32R8V (32MB Flash, 8MB PSRAM)

### DIFF
--- a/boards/esp32-s3-devkitc-1-n32r8v.json
+++ b/boards/esp32-s3-devkitc-1-n32r8v.json
@@ -44,7 +44,7 @@
   "upload": {
     "flash_size": "32MB",
     "maximum_ram_size": 1048576,
-    "maximum_size": 33554432,
+    "maximum_size": 13107200,
     "require_upload_port": true,
     "speed": 921600
   },

--- a/boards/esp32-s3-devkitc-1-n32r8v.json
+++ b/boards/esp32-s3-devkitc-1-n32r8v.json
@@ -1,0 +1,53 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_32MB.csv",
+      "memory_type": "opi_opi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32S3_DEV",
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "opi",
+    "psram_type": "opi",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Espressif ESP32-S3-DevKitC-1-N32R8V (32 MB QD, 8MB PSRAM)",
+  "upload": {
+    "flash_size": "32MB",
+    "maximum_ram_size": 1048576,
+    "maximum_size": 33554432,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html",
+  "vendor": "Espressif"
+}


### PR DESCRIPTION
### Add support for ESP32-S3-DevKitC-1-N32R8V (32MB Flash, 8MB PSRAM)

This commit introduces a new board definition for the **Espressif ESP32-S3-DevKitC-1-N32R8V**, featuring **32MB of flash memory** and **8MB of PSRAM**.

#### Key Changes:
- Added `esp32-s3-devkitc-1-n32r8v.json` with the following configurations:
  - **32MB flash support** (`flash_size: 32MB`), using the latest partition scheme: `default_32MB.csv`.
  - **OPI PSRAM support** (`psram_type: opi`).
  - **Compatibility with the Arduino framework** (it is assumed to work with ESP-IDF as well).
  - **USB CDC enabled by default** (`-DARDUINO_USB_CDC_ON_BOOT=1`).
  - **WiFi & Bluetooth connectivity support**.
  - **Upload speed set to 921600 baud**.

This addition ensures compatibility with the **ESP32-S3-DevKitC-1-N32R8V** when using PlatformIO, allowing developers to fully utilize its extended flash and PSRAM capabilities.

#### References:
- [Espressif Documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html).

#### Related Links:
- Pull request for the new partition scheme: [`default_32MB.csv`](https://github.com/espressif/arduino-esp32/pull/11143).

