### PR TITLE
Esp32ExceptionDecoder: decode stack overflow backtraces

### DIFF
--- a/monitor/filter_exception_decoder.py
+++ b/monitor/filter_exception_decoder.py
@@ -32,7 +32,7 @@ IS_WINDOWS = sys.platform.startswith("win")
 class Esp32ExceptionDecoder(DeviceMonitorFilterBase):
     NAME = "esp32_exception_decoder"
 
-    ADDR_PATTERN = re.compile(r"((?:0x[0-9a-fA-F]{8}[: ]?)+)\s?$")
+    ADDR_PATTERN = re.compile(r"((?:0x[0-9a-fA-F]{8}[: ]?)+)")
     ADDR_SPLIT = re.compile(r"[ :]")
     PREFIX_RE = re.compile(r"^ *")
 


### PR DESCRIPTION
This PR makes esp32_exception_decoder match lines similar to:

```
***ERROR*** A stack overflow in task main has been detected.


Backtrace: 0x40081d06:0x3ffcca50 0x4008554d:0x3ffcca70 0x4008846e:0x3ffcca90 0x4008711f:0x3ffccb10 0x40085648:0x3ffccb30 0x400855fa:0x00000017 |<-CORRUPTED




ELF file SHA256: 91d3d8aaa6b7beec

CPU halted.
```

Note the ` |<-CORRUPTED` part that the old regex doesn't match.