### PR TITLE
Fix build

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -26,7 +26,6 @@ import subprocess
 import sys
 import shutil
 import os
-import pkg_resources
 
 import click
 import semantic_version
@@ -1135,19 +1134,6 @@ def install_python_deps():
                 "Installing windows-curses package",
             )
         )
-
-        # A special "esp-windows-curses" python package is required on Windows
-        # for Menuconfig on IDF <5
-        if not IDF5 and "esp-windows-curses" not in {
-            pkg.key for pkg in pkg_resources.working_set
-        }:
-            env.Execute(
-                env.VerboseAction(
-                    '"%s" -m pip install "file://%s/tools/kconfig_new/esp-windows-curses"'
-                    % (python_exe_path, FRAMEWORK_DIR),
-                    "Installing windows-curses package",
-                )
-            )
 
 def get_idf_venv_dir():
     # The name of the IDF venv contains the IDF version to avoid possible conflicts and


### PR DESCRIPTION
Fixes following error. Can you please make it as release 5.4.1?
```
Processing esp32c3 (board: esp32-c3-devkitm-1; framework: espidf; platform: espressif32)
---------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32-c3-devkitm-1.html
PLATFORM: Espressif 32 (2024.1.1) > Espressif ESP32-C3-DevKitM-1
HARDWARE: ESP32C3 160MHz, 320KB RAM, 4MB Flash
DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-builtin, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
PACKAGES: 
 - framework-espidf @ 3.40405.0 (4.4.5) 
 - tool-cmake @ 3.21.3 
 - tool-esptoolpy @ 1.40700.0 (4.7.0) 
 - tool-mkfatfs @ 2.0.1 
 - tool-mklittlefs @ 3.2.0 
 - tool-mkspiffs @ 2.230.0 (2.30) 
 - tool-ninja @ 1.7.1 
 - toolchain-riscv32-esp @ 8.4.0+2021r2-patch5
ModuleNotFoundError: No module named 'pkg_resources':
  File "/home/danman/.platformio/penv/lib/python3.12/site-packages/platformio/builder/main.py", line 173:
    env.SConscript("$BUILD_SCRIPT")
  File "/home/danman/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 620:
    return _SConscript(self.fs, *files, **subst_kw)
  File "/home/danman/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 280:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "/home/danman/.platformio/platforms/espressif32@src-af758f6cdb258eede9e9febb01c885ee/builder/main.py", line 324:
    target_elf = env.BuildProgram()
  File "/home/danman/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Util/envs.py", line 252:
    return self.method(*nargs, **kwargs)
  File "/home/danman/.platformio/penv/lib/python3.12/site-packages/platformio/builder/tools/piobuild.py", line 62:
    env.ProcessProgramDeps()
  File "/home/danman/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Util/envs.py", line 252:
    return self.method(*nargs, **kwargs)
  File "/home/danman/.platformio/penv/lib/python3.12/site-packages/platformio/builder/tools/piobuild.py", line 142:
    env.BuildFrameworks(env.get("PIOFRAMEWORK"))
  File "/home/danman/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Util/envs.py", line 252:
    return self.method(*nargs, **kwargs)
  File "/home/danman/.platformio/penv/lib/python3.12/site-packages/platformio/builder/tools/piobuild.py", line 352:
    SConscript(env.GetFrameworkScript(name), exports="env")
  File "/home/danman/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 684:
    return method(*args, **kw)
  File "/home/danman/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 620:
    return _SConscript(self.fs, *files, **subst_kw)
  File "/home/danman/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 280:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "/home/danman/.platformio/platforms/espressif32@src-af758f6cdb258eede9e9febb01c885ee/builder/frameworks/espidf.py", line 29:
    import pkg_resources
=========================================================== [FAILED] Took 2.17 seconds ===========================================================

Environment    Status    Duration
-------------  --------  ------------
esp32c3        FAILED    00:00:02.166
====================================================== 1 failed, 0 succeeded in 00:00:02.166 ======================================================

```