### PR TITLE
use provided upload port

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -32,7 +32,8 @@ def BeforeUpload(target, source, env):
     if "BOARD" in env:
         upload_options = env.BoardConfig().get("upload", {})
 
-    env.AutodetectUploadPort()
+    if not env.subst("$UPLOAD_PORT"):
+        env.AutodetectUploadPort()
 
     before_ports = get_serial_ports()
     if upload_options.get("use_1200bps_touch", False):


### PR DESCRIPTION
and if none found use auto detection for the port. Partially fixes #1582 
When the port is provided via Platformio VSC extension it is still auto detected. Dont know how to get choosen settings from the Platformio VSC extension.