### PR TITLE
Add Sparkfun ESP32-S3 Thing Plus board definition

### DIFF
--- a/boards/sparkfun_esp32s3_thing_plus.json
+++ b/boards/sparkfun_esp32s3_thing_plus.json
@@ -1,0 +1,42 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_4MB.csv"
+    },
+    "core": "esp32",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "mcu": "esp32s3",
+    "variant": "sparkfun_esp32s3_thing_plus",
+    "extra_flags": [
+      "-DARDUINO_ESP32S3_THING_PLUS",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_USB_MODE=1"
+    ]
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "usb"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Sparkfun ESP32-S3 Thing Plus",
+  "upload": {
+    "flash_size": "4MB",
+    "psram_size": "2MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.sparkfun.com/sparkfun-thing-plus-esp32-s3.html",
+  "vendor": "SparkFun"
+}


### PR DESCRIPTION
## Description:

Add Sparkfun ESP32-S3 Thing Plus board definition

## Checklist:

- [x]  The pull request is done against the latest develop branch
- [x]  Only relevant files were touched
- [x]  Only one feature/fix was added per PR, more changes are allowed when changing boards.json
- [x]  I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/develop/CONTRIBUTING.md).