### PR TITLE
wireless tracker board file

### DIFF
--- a/boards/heltec_wireless_tracker.json
+++ b/boards/heltec_wireless_tracker.json
@@ -1,0 +1,49 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DWireless_Track",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "heltec_wireless_tracker"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "lora",
+    "gps"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Heltec Wireless Tracker",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 1036800
+  },
+  "url": "https://heltec.org/project/wireless-tracker/",
+  "vendor": "Heltec"
+}


### PR DESCRIPTION
It seemed that #1148 was being held up due to the original contributor's unfamiliarity with git and lack of support upstream at espressif. But espressif has now added support from their side, so I think this board profile can go in Platformio. I just did the git grunt work but am unsure how to test it as they did with my fork. I'm allowing edits by maintainers in case they want to make any changes in my absence.