### PR TITLE
Added Waveshare ESP32-S3 Pico (no OTA) board definition and example p…

### DIFF
--- a/boards/waveshare_esp32s3_pico_no_ota.json
+++ b/boards/waveshare_esp32s3_pico_no_ota.json
@@ -1,0 +1,34 @@
+{
+  "name": "Waveshare ESP32-S3 Pico no OTA",
+  "url": "https://www.waveshare.com/wiki/ESP32-S3-Pico",
+  "vendor": "Waveshare",
+  "platform": "espressif32",
+  "chip": "ESP32-S3",
+  "psram": "enabled",
+  "build": {
+    "core": "esp32",
+    "cpu": "esp32s3",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "variant": "esp32s3",
+    "board": "esp32s3",
+    "mcu": "esp32s3"
+  },
+  "frameworks": ["arduino"],
+  "upload": {
+    "maximum_ram_size": 1310720,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "flash_size": "16MB"
+  },
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "attributes": {
+  "psram_size": "8MB",
+  "flash_size": "16MB",
+  "rgb_led_pin": 21,
+  "ota": false
+}
+}

--- a/examples/waveshare_esp32s3_pico_no_ota/.gitignore
+++ b/examples/waveshare_esp32s3_pico_no_ota/.gitignore
@@ -1,0 +1,2 @@
+.pio
+.vscode

--- a/examples/waveshare_esp32s3_pico_no_ota/include/README
+++ b/examples/waveshare_esp32s3_pico_no_ota/include/README
@@ -1,0 +1,37 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the convention is to give header files names that end with `.h'.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/examples/waveshare_esp32s3_pico_no_ota/lib/README
+++ b/examples/waveshare_esp32s3_pico_no_ota/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into the executable file.
+
+The source code of each library should be placed in a separate directory
+("lib/your_library_name/[Code]").
+
+For example, see the structure of the following example libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional. for custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+Example contents of `src/main.c` using Foo and Bar:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+The PlatformIO Library Dependency Finder will find automatically dependent
+libraries by scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/examples/waveshare_esp32s3_pico_no_ota/partitions/waveshare_esp32s3_pico_16MB_no_ota.csv
+++ b/examples/waveshare_esp32s3_pico_no_ota/partitions/waveshare_esp32s3_pico_16MB_no_ota.csv
@@ -1,0 +1,4 @@
+# Name, Type, SubType, Offset, Size, Flags
+nvs,      data, nvs,     0x9000,   0x6000,
+app0,     app,  factory, 0x10000,  0xE00000,
+spiffs,   data, spiffs,  0xE10000, 0x1F0000

--- a/examples/waveshare_esp32s3_pico_no_ota/platformio.ini
+++ b/examples/waveshare_esp32s3_pico_no_ota/platformio.ini
@@ -1,0 +1,26 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:Waveshare ESP32-S3 Pico]
+platform = espressif32
+board = waveshare_esp32s3_pico_no_ota
+framework = arduino
+monitor_speed = 115200
+upload_speed = 460800
+board_build.psram = enabled
+board_build.flash_size = 16MB
+board_build.partitions = partitions/waveshare_esp32s3_pico_16MB_no_ota.csv
+build_flags =
+  -DBOARD_HAS_PSRAM
+  -mfix-esp32-psram-cache-issue
+
+lib_deps =
+  adafruit/Adafruit NeoPixel
+

--- a/examples/waveshare_esp32s3_pico_no_ota/readme.md
+++ b/examples/waveshare_esp32s3_pico_no_ota/readme.md
@@ -1,0 +1,19 @@
+# Waveshare ESP32-S3 Pico (no OTA) — Example Project
+
+This example demonstrates basic PSRAM detection and RGB LED control.
+
+## Board details
+
+- PSRAM size: 2MB (detected via `ESP.getPsramSize()`)
+- Flash size: 16MB
+- RGB LED is connected to **GPIO21**
+- Partition table: `waveshare_esp32s3_pico_16MB_no_ota.csv`
+- More Waveshare ESP32-S3 Pico docuemntation can be found [here](https://www.waveshare.com/wiki/ESP32-S3-Pico)
+
+## About the example
+
+In this example we operate on the built in RGB LED, chceck the total size of PSRAM and the available space in the PSRAM.
+
+## Other information
+
+Tested with Arduino framework and PlatformIO IDE v. 3.3.4

--- a/examples/waveshare_esp32s3_pico_no_ota/src/main.cpp
+++ b/examples/waveshare_esp32s3_pico_no_ota/src/main.cpp
@@ -1,0 +1,45 @@
+#include <Arduino.h>
+#include <esp_heap_caps.h>
+#include <Adafruit_NeoPixel.h>
+
+#define LED_PIN    21      // GPIO21
+#define LED_COUNT  1       // Number of RGB LEDs
+
+Adafruit_NeoPixel strip(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800);
+
+void setup() {
+  Serial.begin(115200);
+  Serial.printf("Total PSRAM: %u bytes\n", ESP.getPsramSize());
+  strip.begin();
+  strip.show(); // Turns RGB LED off
+  strip.setBrightness(30); // Set brightness: 0-255
+}
+
+void loop() {
+  // RGB LED lights red
+  strip.setPixelColor(0, strip.Color(255, 0, 0));
+  strip.show();
+  Serial.printf("RGB LED - red\n");
+  delay(1000);
+
+  // RGB LED lights green
+  strip.setPixelColor(0, strip.Color(0, 255, 0));
+  strip.show();
+  Serial.printf("RGB LED - green\n");
+  delay(1000);
+
+  // RGB LED lights blue
+  strip.setPixelColor(0, strip.Color(0, 0, 255));
+  strip.show();
+  Serial.printf("RGB LED - blue\n");
+  delay(1000);
+
+  // RGB LED lights white
+  strip.setPixelColor(0, strip.Color(255, 255, 255));
+  strip.show();
+  Serial.printf("RGB LED - white\n");
+  delay(1000);
+
+  // Print free PSRAM to serial console
+  Serial.printf("Free PSRAM: %u bytes\n", ESP.getFreePsram());
+}

--- a/examples/waveshare_esp32s3_pico_no_ota/test/README
+++ b/examples/waveshare_esp32s3_pico_no_ota/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Test Runner and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/en/latest/advanced/unit-testing/index.html


### PR DESCRIPTION
### New board: Waveshare ESP32-S3 Pico (no OTA)

This PR adds support for the Waveshare ESP32-S3 Pico board based on the ESP32-S3, with the Arduino framework.

#### ✅ Board features

- 16MB flash
- 2MB PSRAM (detected and usable via `ESP.getPsramSize()`)
- Onboard RGB LED connected to **GPIO21**
- Custom partition table (`waveshare_esp32s3_pico_16MB_no_ota.csv`) with full flash usage and **no OTA**

#### 📦 Included files

- `boards/waveshare_esp32s3_pico_no_ota.json`
- `examples/waveshare_esp32s3_pico_no_ota/platformio.ini`
- `examples/waveshare_esp32s3_pico_no_ota/src/main.cpp`
- `examples/waveshare_esp32s3_pico_no_ota/README.md`
- `examples/waveshare_esp32s3_pico_no_ota/partitions/waveshare_esp32s3_pico_16MB_no_ota.csv`

#### 🔧 Framework compatibility

Tested with:
- Arduino framework
- PlatformIO IDE v3.3.4

#### 📚 Reference

- [Waveshare ESP32-S3 Pico documentation](https://www.waveshare.com/wiki/ESP32-S3-Pico)

Let me know if you'd like me to add an OTA Arduino variant.