### PR TITLE
Add support for Geekble nano board

### DIFF
--- a/boards/geekble_nano.json
+++ b/boards/geekble_nano.json
@@ -1,0 +1,33 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_GEEKBLE_NANO",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      ["0x303A", "0x82C5"]
+    ],
+    "mcu": "esp32s3",
+    "variant": "geekble_nano"
+  },
+  "connectivity": ["bluetooth", "wifi"],
+  "frameworks": ["arduino", "espidf"],
+  "name": "Geekble nano",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_size": 4194304,
+    "speed": 921600,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://sooddragon.com",
+  "vendor": "Geekble"
+}


### PR DESCRIPTION
 I am the developer of the "Geekble nano" board. This board is based on ESP32-S3 and designed for creators and students.

MCU: ESP32-S3

USB VID/PID: 0x303A / 0x82C5

Features: Integrated USB CDC, Compact size.
Please review and add this board to the official list. Thank you!