### PR TITLE
Add Freenove ESP32-S3 WROOM Lite 16MB

### DIFF
--- a/boards/freenove_esp32_s3_wroom_lite_16.json
+++ b/boards/freenove_esp32_s3_wroom_lite_16.json
@@ -1,0 +1,55 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_8MB.csv",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32S3_DEV",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DBOARD_HAS_PSRAM",    
+      "-DARDUINO_USB_MODE=0",
+      "-DARDUINO_USB_CDC_ON_BOOT=0"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "psram_type": "opi",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Freenove ESP32-S3 WROOM N16R8 (16MB Flash / 8MB PSRAM)",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://github.com/Freenove/Freenove_ESP32_S3_WROOM_Board_Lite",
+  "vendor": "Freenove"
+}


### PR DESCRIPTION
Add Configuration for 16MB Flash  version of ESP32-3 WROOM Lite (N16R8)

This board was requested in this Issue https://github.com/platformio/platform-espressif32/issues/1651

I'm not sure if there is an option for a default partition that use 16MB

Theres is also exist a board "Lite" version with 8MB (N8R8) but configuration is compatible with current [boards/freenove_esp32_s3_wroom.json](url)

```JSON
"arduino": {
      "ldscript": "esp32s3_out.ld",
      "partitions": "default_8MB.csv",
      "memory_type": "qio_opi"
    },
