### PR TITLE
feat(board): Add support for Elektrofuzzis ftSwarm family boards

### DIFF
--- a/boards/ftSwarmcontrolusbc.json
+++ b/boards/ftSwarmcontrolusbc.json
@@ -1,0 +1,47 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "huge_app.csv",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=0",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [ ["0x1A86", "0x7523"] ],
+    "mcu": "esp32s3",
+    "variant": "ftswarmcontrolusbc"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "ftSwarmControl USB C",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 3145728,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://elektrofuzzis.github.io",
+  "vendor": "Elektrofuzzis"
+}

--- a/boards/ftswarmcontrolusbmicro.json
+++ b/boards/ftswarmcontrolusbmicro.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld",
+      "partitions": "huge_app.csv"
+    },
+    "core": "esp32",
+    "extra_flags": "-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -DARDUINO_EVENT_RUNNING_CORE=0 -DARDUINO_RUNNING_CORE=1",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "hwids": [ ["0x10C4", "0xEA60"] ],
+    "mcu": "esp32",
+    "variant": "ftswarmcontrolusbmicro"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "default_framework": "arduino",
+  "name": "ftSwarmControlUSBMicro",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 3145728,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://elektrofuzzis.github.io",
+  "vendor": "Elektrofuzzis"
+}

--- a/boards/ftswarmduino.json
+++ b/boards/ftswarmduino.json
@@ -1,0 +1,47 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "huge_app.csv",
+      "memory_type": "qio_qspi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=0",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [ ["0x1A86", "0x7523"] ],
+    "mcu": "esp32s3",
+    "variant": "ftswarmduino"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "ftSwarmDuino",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 3145728,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://elektrofuzzis.github.io",
+  "vendor": "Elektrofuzzis"
+}

--- a/boards/ftswarmjst.json
+++ b/boards/ftswarmjst.json
@@ -1,0 +1,37 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld",
+      "partitions": "huge_app.csv"
+    },
+    "core": "esp32",
+    "extra_flags": "-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -DARDUINO_EVENT_RUNNING_CORE=0 -DARDUINO_RUNNING_CORE=1",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "ftSwarmJST"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "default_framework": "arduino",
+  "name": "ftswarmjst",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 3145728,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://elektrofuzzis.github.io",
+  "vendor": "Elektrofuzzis"
+}

--- a/boards/ftswarmpwrdrive.json
+++ b/boards/ftswarmpwrdrive.json
@@ -1,0 +1,47 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "huge_app.csv",
+      "memory_type": "qio_qspi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=0",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [ ["0x1A86", "0x7523"] ],
+    "mcu": "esp32s3",
+    "variant": "ftswarmpwrdrive"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "ftSwarmPwrDrive",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 3145728,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://elektrofuzzis.github.io",
+  "vendor": "Elektrofuzzis"
+}

--- a/boards/ftswarmrc.json
+++ b/boards/ftswarmrc.json
@@ -1,0 +1,47 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "huge_app.csv",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=0",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [ ["0x1A86", "0x7523"] ],
+    "mcu": "esp32s3",
+    "variant": "ftswarmrc"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "ftSwarmRC",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 3145728,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://elektrofuzzis.github.io",
+  "vendor": "Elektrofuzzis"
+}

--- a/boards/ftswarmrs.json
+++ b/boards/ftswarmrs.json
@@ -1,0 +1,47 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_8MB.csv",
+      "memory_type": "qio_qspi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=0",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [ ["0x1A86", "0x7523"] ],
+    "mcu": "esp32s3",
+    "variant": "ftswarmrs"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "ftSwarmRS",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size":  3342336,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://elektrofuzzis.github.io",
+  "vendor": "Elektrofuzzis"
+}

--- a/boards/ftswarmxl.json
+++ b/boards/ftswarmxl.json
@@ -1,0 +1,47 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "huge_app.csv",
+      "memory_type": "qio_qspi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=0",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [ ["0x1A86", "0x7523"] ],
+    "mcu": "esp32s3",
+    "variant": "ftswarmxl"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "ftSwarmXL",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 3145728,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://elektrofuzzis.github.io",
+  "vendor": "Elektrofuzzis"
+}


### PR DESCRIPTION
This commit introduces a new board definitions for the Elektrofuzzis **ftSwarm-family** (ftSwarmRC, ftSwarmRS, ftSwarmXL, , ftSwarmControlUSBC, ftSwarmControlUSBMicro, ftSwarmDuino, ftSwarmPwrDrive, ftSwarmJST)

**Key Changes:**
Added esp32-S3 based board files ftSwarmRC.json, ftSwarmRS.json, ftSwarmXL.json, ftSwarmControlUSBC.json, ftSwarmDuino.json, ftSwarmPwrDrive.json.
Added esp32 board files ftSwarmControlUSBMicro.json, ftSwarmJST.json.
Compatibility with the Arduino framework.

**References:**
[Elektrofuzzis Documentation](https://elektrofuzzis.github.io/de/index.html)

**Related Links:**
Pull request for the boards in arduino-esp32: https://github.com/espressif/arduino-esp32/pull/12683