### PR TITLE
Add DFRobot Edge101 IOT Controller

### DIFF
--- a/boards/dfrobot_edge101.json
+++ b/boards/dfrobot_edge101.json
@@ -1,0 +1,45 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32_out.ld",
+      "partitions": "app3M_fat9M_16MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_DFROBOT_EDGE101",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "hwids": [
+      ["0x1A86", "0x55D4"]
+    ],
+    "mcu": "esp32",
+    "variant": "dfrobot_edge101"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "DFRobot Edge101 IOT Controller",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://wiki.dfrobot.com/SKU_DFR0886_Edge101_IOT_Controller",
+  "vendor": "DFRobot"
+}


### PR DESCRIPTION
This PR adds support for the DFRobot Edge101 IOT Controller (SKU DFR0886).
  - Wiki: https://wiki.dfrobot.com/dfr0886/docs/23040
  - Product: https://www.dfrobot.com/product-2739.html
## Hardware
  - USB-serial: CH9102F
  - Ethernet: IP101GRI PHY, RMII
  - RTC: PCF8563T on I2C
  - microSD (SPI)
  - CAN: TJA1050 (isolated)
  - RS485: TPT75176H (isolated)
  - Optional mini-PCIe 4G modem slot
  - User LED: GPIO15, User button: GPIO38

Requires https://github.com/espressif/arduino-esp32/pull/12742 and resolves #1619